### PR TITLE
Update Wallet Backup Screen

### DIFF
--- a/lib/app/widgets/app_screen_with_header_mobile.dart
+++ b/lib/app/widgets/app_screen_with_header_mobile.dart
@@ -22,7 +22,7 @@ class AppScreenWithHeaderMobile extends StatelessWidget {
         slivers: [
           SliverToBoxAdapter(
             child: SizedBox(
-              height: 190,
+              height: 140,
               child: LayoutBuilder(
                 builder: (BuildContext context, BoxConstraints constraints) {
                   return RegistrationHeader(

--- a/lib/app/widgets/splash.dart
+++ b/lib/app/widgets/splash.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:genius_wallet/app/bloc/app_bloc.dart';
 import 'package:genius_wallet/app/widgets/app_screen_view.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
 import 'package:go_router/go_router.dart';
 
 class Splash extends StatelessWidget {
@@ -20,6 +21,7 @@ class Splash extends StatelessWidget {
         }
       },
       child: Scaffold(
+        backgroundColor: GeniusWalletColors.deepBlue,
         body: AppScreenView(
           body: SizedBox(
             width: MediaQuery.of(context).size.width,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,6 +40,21 @@ class MyApp extends StatelessWidget {
         child: MaterialApp.router(
           title: 'Flutter Demo',
           theme: ThemeData(
+            checkboxTheme: CheckboxThemeData(
+                side: const BorderSide(
+                    color: GeniusWalletColors.lightGreenPrimary),
+                checkColor: MaterialStateProperty.resolveWith((states) {
+                  if (!states.contains(MaterialState.selected)) {
+                    return Colors.transparent;
+                  }
+                  return GeniusWalletColors.deepBlue;
+                }),
+                fillColor: MaterialStateProperty.resolveWith((states) {
+                  if (!states.contains(MaterialState.selected)) {
+                    return Colors.transparent;
+                  }
+                  return GeniusWalletColors.lightGreenPrimary;
+                })),
             buttonTheme: const ButtonThemeData(padding: EdgeInsets.all(0)),
             primarySwatch: Colors.blue,
             scaffoldBackgroundColor: GeniusWalletColors.deepBlue,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,7 +57,7 @@ class MyApp extends StatelessWidget {
                 })),
             buttonTheme: const ButtonThemeData(padding: EdgeInsets.all(0)),
             primarySwatch: Colors.blue,
-            scaffoldBackgroundColor: GeniusWalletColors.deepBlue,
+            scaffoldBackgroundColor: GeniusWalletColors.deepBlueSecondary,
             colorScheme: const ColorScheme
                 .dark(), //TODO: replace this once we have theme generated
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,7 +47,7 @@ class MyApp extends StatelessWidget {
                   if (!states.contains(MaterialState.selected)) {
                     return Colors.transparent;
                   }
-                  return GeniusWalletColors.deepBlue;
+                  return GeniusWalletColors.btnText;
                 }),
                 fillColor: MaterialStateProperty.resolveWith((states) {
                   if (!states.contains(MaterialState.selected)) {

--- a/lib/onboarding/new_wallet/view/backup_phrase_screen.dart
+++ b/lib/onboarding/new_wallet/view/backup_phrase_screen.dart
@@ -40,13 +40,18 @@ class _BackupPhraseViewMobile extends StatelessWidget {
         children: [
           SizedBox(
             width: MediaQuery.of(context).size.width,
-            height: 190,
+            height: 100,
             child: LayoutBuilder(builder: (context, constraints) {
               return RegistrationHeader(constraints);
             }),
           ),
           SizedBox(
-            height: MediaQuery.of(context).size.height * 0.55,
+            width: MediaQuery.of(context).size.width * .86,
+            height: 50,
+            child: const Text(GeniusWalletText.helpTextWalletBackup),
+          ),
+          SizedBox(
+            height: MediaQuery.of(context).size.height * 0.62,
           ),
           SizedBox(
             height: 60,

--- a/lib/onboarding/new_wallet/view/backup_phrase_screen.dart
+++ b/lib/onboarding/new_wallet/view/backup_phrase_screen.dart
@@ -6,6 +6,7 @@ import 'package:genius_wallet/app/widgets/app_screen_view.dart';
 import 'package:genius_wallet/app/widgets/app_screen_with_header_desktop.dart';
 import 'package:genius_wallet/app/widgets/desktop_body_container.dart';
 import 'package:genius_wallet/onboarding/new_wallet/bloc/new_wallet_bloc.dart';
+import 'package:genius_wallet/theme/genius_wallet_text.dart';
 import 'package:genius_wallet/widgets/components/continue_button/isactive_false.g.dart';
 import 'package:genius_wallet/widgets/components/continue_button/isactive_true.g.dart';
 import 'package:genius_wallet/widgets/components/custom/wallet_agreement_custom.dart';
@@ -45,16 +46,11 @@ class _BackupPhraseViewMobile extends StatelessWidget {
             }),
           ),
           SizedBox(
-            height: MediaQuery.of(context).size.height * 0.2,
+            height: MediaQuery.of(context).size.height * 0.55,
           ),
-          Image.asset(
-            'assets/images/shield_icon.png',
-            package: 'genius_wallet',
-          ),
-          const SizedBox(height: 30),
           SizedBox(
-            height: 50,
-            width: MediaQuery.of(context).size.width * 0.8,
+            height: 60,
+            width: MediaQuery.of(context).size.width * 0.86,
             child: LayoutBuilder(
               builder: (context, constraints) {
                 return WalletAgreementCustom(
@@ -62,13 +58,11 @@ class _BackupPhraseViewMobile extends StatelessWidget {
                   onChanged: (value) {
                     context.read<NewWalletBloc>().add(ToggleCheckbox());
                   },
-                  text:
-                      'I understand that if I lose my recovery words, I will not be able to access my wallet.',
+                  text: GeniusWalletText.helpRecoveryWords,
                 );
               },
             ),
           ),
-          const SizedBox(height: 20)
         ],
       ),
       footer: SizedBox(
@@ -137,8 +131,7 @@ class _BackupPhraseViewDesktop extends StatelessWidget {
                       onChanged: (value) {
                         context.read<NewWalletBloc>().add(ToggleCheckbox());
                       },
-                      text:
-                          'I understand that if I lose my recovery words, I will not be able to access my wallet.',
+                      text: GeniusWalletText.helpRecoveryWords,
                     );
                   },
                 ),

--- a/lib/onboarding/new_wallet/view/backup_phrase_screen.dart
+++ b/lib/onboarding/new_wallet/view/backup_phrase_screen.dart
@@ -40,18 +40,16 @@ class _BackupPhraseViewMobile extends StatelessWidget {
         children: [
           SizedBox(
             width: MediaQuery.of(context).size.width,
-            height: 100,
+            height: 190,
             child: LayoutBuilder(builder: (context, constraints) {
-              return RegistrationHeader(constraints);
+              return RegistrationHeader(
+                constraints,
+                ovrSubtitle: GeniusWalletText.helpTextWalletBackup,
+              );
             }),
           ),
           SizedBox(
-            width: MediaQuery.of(context).size.width * .86,
-            height: 50,
-            child: const Text(GeniusWalletText.helpTextWalletBackup),
-          ),
-          SizedBox(
-            height: MediaQuery.of(context).size.height * 0.62,
+            height: MediaQuery.of(context).size.height * 0.58,
           ),
           SizedBox(
             height: 60,

--- a/lib/onboarding/new_wallet/view/recovery_phrase_screen.dart
+++ b/lib/onboarding/new_wallet/view/recovery_phrase_screen.dart
@@ -7,6 +7,9 @@ import 'package:genius_wallet/app/widgets/app_screen_with_header_desktop.dart';
 import 'package:genius_wallet/app/widgets/desktop_body_container.dart';
 import 'package:genius_wallet/onboarding/new_wallet/bloc/new_wallet_bloc.dart';
 import 'package:genius_wallet/onboarding/widgets/recovery_words.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
+import 'package:genius_wallet/theme/genius_wallet_font_size.dart';
+import 'package:genius_wallet/theme/genius_wallet_text.dart';
 import 'package:genius_wallet/widgets/components/continue_button/isactive_true.g.dart';
 import 'package:genius_wallet/widgets/components/registration_header.g.dart';
 
@@ -42,9 +45,8 @@ class _RecoveryPhraseViewDesktop extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AppScreenWithHeaderDesktop(
-      title: 'Your Recovery Phrase',
-      subtitle:
-          'Write down or copy these words in the right order and save them somewhere safe',
+      title: GeniusWalletText.titleRecovery,
+      subtitle: GeniusWalletText.helpRecoveryPhrase,
       body: Center(
         child: DesktopBodyContainer(
           child: Column(
@@ -88,14 +90,13 @@ class _RecoveryPhraseViewMobile extends StatelessWidget {
         children: [
           SizedBox(
             width: MediaQuery.of(context).size.width,
-            height: 190,
+            height: 280,
             child: LayoutBuilder(
               builder: (context, constraints) {
                 return RegistrationHeader(
                   constraints,
-                  ovrTitle: 'Your Recovery Phrase',
-                  ovrSubtitle:
-                      'Write down or copy these words in the right order and save them somewhere safe',
+                  ovrTitle: GeniusWalletText.titleRecovery,
+                  ovrSubtitle: GeniusWalletText.helpRecoveryPhrase,
                 );
               },
             ),
@@ -145,7 +146,10 @@ class _WordsAndCopyState extends State<_WordsAndCopy> {
             return const CircularProgressIndicator();
           },
         ),
-        MaterialButton(
+        const SizedBox(
+          height: 20,
+        ),
+        TextButton.icon(
           onPressed: () async {
             await FlutterClipboard.copy(
                 context.read<NewWalletBloc>().state.recoveryWords.join(' '));
@@ -158,11 +162,19 @@ class _WordsAndCopyState extends State<_WordsAndCopy> {
               ),
             );
           },
-          child: const Text(
-            'Copy',
+          style: OutlinedButton.styleFrom(
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+            padding: const EdgeInsets.fromLTRB(15, 10, 15, 10),
+            side: const BorderSide(
+                width: 1.0, color: GeniusWalletColors.btnCopyBorder),
+          ),
+          icon: const Icon(Icons.content_copy,
+              color: Colors.white, size: GeniusWalletFontSize.base),
+          label: const Text(
+            ' ${GeniusWalletText.btnCopy}',
             style: TextStyle(
-              fontSize: 18,
-            ),
+                fontSize: GeniusWalletFontSize.medium, color: Colors.white),
           ),
         ),
       ],

--- a/lib/onboarding/new_wallet/view/verify_recovery_phrase_screen.dart
+++ b/lib/onboarding/new_wallet/view/verify_recovery_phrase_screen.dart
@@ -131,11 +131,11 @@ class _VerifyRecoveryPhraseViewMobile extends StatelessWidget {
       title: 'Verify Your Recovery Phrase',
       subtitle:
           'Tap the words to put them next to each other in the correct order',
-      body: Column(
+      body: const Column(
         mainAxisAlignment: MainAxisAlignment.center,
-        children: const [
+        children: [
           Padding(
-            padding: EdgeInsets.only(left: 40.0, right: 40.0, top: 40.0),
+            padding: EdgeInsets.only(left: 20.0, right: 20.0, top: 40.0),
             child: _InputAndWords(),
           ),
           SizedBox(
@@ -170,7 +170,7 @@ class _InputAndWords extends StatelessWidget {
           selectedWords: context.watch<NewWalletBloc>().state.selectedWords,
         ),
         const SizedBox(
-          height: 50,
+          height: 80,
         ),
         RecoveryWords(
           recoveryWords: context.read<NewWalletBloc>().state.shuffledWords,

--- a/lib/onboarding/view/wallet_creation_screen.dart
+++ b/lib/onboarding/view/wallet_creation_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:genius_wallet/app/bloc/app_bloc.dart';
 import 'package:genius_wallet/app/widgets/app_screen_view.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
 import 'package:genius_wallet/widgets/components/wallet_button/type_create.g.dart';
 import 'package:genius_wallet/widgets/components/wallet_button/type_existing.g.dart';
 
@@ -10,6 +11,7 @@ class LandingScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: GeniusWalletColors.deepBlue,
       body: AppScreenView(
         body: Container(
           padding: const EdgeInsets.symmetric(horizontal: 40),

--- a/lib/onboarding/widgets/recovery_words.dart
+++ b/lib/onboarding/widgets/recovery_words.dart
@@ -27,8 +27,8 @@ class RecoveryWords extends StatelessWidget {
         gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: _numCols,
           mainAxisSpacing: 10,
-          crossAxisSpacing: 20,
-          childAspectRatio: 3,
+          crossAxisSpacing: 10,
+          childAspectRatio: 2.5,
         ),
         itemCount: recoveryWords.length,
         itemBuilder: (context, index) {

--- a/lib/onboarding/widgets/recovery_words_input.dart
+++ b/lib/onboarding/widgets/recovery_words_input.dart
@@ -11,9 +11,13 @@ class RecoveryWordsInput extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: GeniusWalletColors.blue500.withOpacity(0.1),
-      height: 200,
-      width: MediaQuery.of(context).size.width * 0.8,
+      decoration: BoxDecoration(
+          border: Border.all(color: GeniusWalletColors.gray500),
+          borderRadius: const BorderRadius.all(Radius.circular(15)),
+          color: GeniusWalletColors.grayPrimary),
+      padding: const EdgeInsets.all(16),
+      height: 180,
+      width: MediaQuery.of(context).size.width,
       child: Text(selectedWords.join(' ')),
     );
   }

--- a/lib/theme/genius_wallet_colors.g.dart
+++ b/lib/theme/genius_wallet_colors.g.dart
@@ -43,6 +43,8 @@ class GeniusWalletColors {
 
   static const Color grayPrimary = Color.fromRGBO(255, 255, 255, 0.05);
 
+  static const Color btnText = Color.fromRGBO(0, 11, 24, 1);
+
   static const Color btnDisabled = Color.fromRGBO(188, 188, 188, 1);
 
   static const Color btnTextDisabled = Color.fromRGBO(101, 101, 101, 1);

--- a/lib/theme/genius_wallet_colors.g.dart
+++ b/lib/theme/genius_wallet_colors.g.dart
@@ -35,7 +35,19 @@ class GeniusWalletColors {
 
   static const Color deepBlue = Color.fromRGBO(18, 33, 54, 1);
 
+  static const Color deepBlueSecondary = Color.fromRGBO(11, 20, 32, 1);
+
   static const Color lightGreenPrimary = Color.fromRGBO(0, 234, 174, 1);
 
   static const Color lightGreenSecondary = Color.fromRGBO(1, 204, 149, 1);
+
+  static const Color grayPrimary = Color.fromRGBO(255, 255, 255, 0.05);
+
+  static const Color btnDisabled = Color.fromRGBO(188, 188, 188, 1);
+
+  static const Color btnTextDisabled = Color.fromRGBO(101, 101, 101, 1);
+
+  static const Color btnGradientBlue = Color.fromRGBO(0, 104, 239, 1);
+
+  static const Color btnGradientGreen = Color.fromRGBO(1, 221, 166, 1);
 }

--- a/lib/theme/genius_wallet_colors.g.dart
+++ b/lib/theme/genius_wallet_colors.g.dart
@@ -41,7 +41,7 @@ class GeniusWalletColors {
 
   static const Color lightGreenSecondary = Color.fromRGBO(1, 204, 149, 1);
 
-  static const Color grayPrimary = Color.fromRGBO(255, 255, 255, 0.05);
+  static const Color grayPrimary = Color.fromRGBO(21, 30, 41, 1);
 
   static const Color btnText = Color.fromRGBO(0, 11, 24, 1);
 
@@ -52,4 +52,6 @@ class GeniusWalletColors {
   static const Color btnGradientBlue = Color.fromRGBO(0, 104, 239, 1);
 
   static const Color btnGradientGreen = Color.fromRGBO(1, 221, 166, 1);
+
+  static const Color btnCopyBorder = Color.fromRGBO(255, 255, 255, 0.30);
 }

--- a/lib/theme/genius_wallet_consts.dart
+++ b/lib/theme/genius_wallet_consts.dart
@@ -1,0 +1,3 @@
+class GeniusWalletConsts {
+  static const int pinCount = 4;
+}

--- a/lib/theme/genius_wallet_font_size.dart
+++ b/lib/theme/genius_wallet_font_size.dart
@@ -1,4 +1,5 @@
 class GeniusWalletFontSize {
   static const double base = 14.0;
+  static const double medium = 16.0;
   static const double title = 20.0;
 }

--- a/lib/theme/genius_wallet_font_size.dart
+++ b/lib/theme/genius_wallet_font_size.dart
@@ -1,3 +1,4 @@
 class GeniusWalletFontSize {
   static const double base = 14.0;
+  static const double title = 20.0;
 }

--- a/lib/theme/genius_wallet_gradient.dart
+++ b/lib/theme/genius_wallet_gradient.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
+
+class GeniusWalletGradient {
+  static LinearGradient greenBlueGreenGradient = const LinearGradient(
+    begin: Alignment.topCenter,
+    end: Alignment.bottomCenter,
+    colors: <Color>[
+      GeniusWalletColors.btnGradientBlue,
+      GeniusWalletColors.btnGradientGreen
+    ],
+  );
+}

--- a/lib/theme/genius_wallet_text.dart
+++ b/lib/theme/genius_wallet_text.dart
@@ -1,0 +1,13 @@
+class GeniusWalletText {
+  // Title Text
+  static const String titleWalletBackup = 'Wallet Backup';
+
+  // Help Text
+  static const String helpTextWalletBackup =
+      'In the next step you will see 12 words that allows you to recover a wallet.';
+  static const String helpRecoveryWords =
+      'I understand that if I lose my recovery words, I will not be able to access my wallet.';
+
+  // Button Text
+  static const String btnContinue = 'Continue';
+}

--- a/lib/theme/genius_wallet_text.dart
+++ b/lib/theme/genius_wallet_text.dart
@@ -1,13 +1,17 @@
 class GeniusWalletText {
   // Title Text
   static const String titleWalletBackup = 'Wallet Backup';
+  static const String titleRecovery = 'Your Recovery Phrase';
 
   // Help Text
   static const String helpTextWalletBackup =
       'In the next step you will see 12 words that allows you to recover a wallet.';
   static const String helpRecoveryWords =
       'I understand that if I lose my recovery words, I will not be able to access my wallet.';
+  static const String helpRecoveryPhrase =
+      'Write down or copy these words in the right order and save them somewhere safe';
 
   // Button Text
   static const String btnContinue = 'Continue';
+  static const String btnCopy = 'Copy';
 }

--- a/lib/widgets/components/continue_button/isactive_false.g.dart
+++ b/lib/widgets/components/continue_button/isactive_false.g.dart
@@ -5,6 +5,8 @@
 // *********************************************************************************
 
 import 'package:flutter/material.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
+import 'package:genius_wallet/theme/genius_wallet_text.dart';
 import 'package:genius_wallet/widgets/components/custom/isactive_false_custom.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 
@@ -26,7 +28,7 @@ class _IsactiveFalse extends State<IsactiveFalse> {
   @override
   Widget build(BuildContext context) {
     return Container(
-        decoration: BoxDecoration(),
+        decoration: const BoxDecoration(),
         child: IsactiveFalseCustom(
             child: Stack(children: [
           Positioned(
@@ -44,7 +46,8 @@ class _IsactiveFalse extends State<IsactiveFalse> {
                   height: widget.constraints.maxHeight * 1.0,
                   width: widget.constraints.maxWidth * 1.0,
                   decoration: BoxDecoration(
-                    color: Color(0xff73788c),
+                    borderRadius: BorderRadius.circular(48),
+                    color: GeniusWalletColors.btnDisabled,
                   ),
                 ),
               ),
@@ -57,13 +60,13 @@ class _IsactiveFalse extends State<IsactiveFalse> {
                     height: widget.constraints.maxHeight * 0.2826086956521739,
                     width: widget.constraints.maxWidth * 0.27936507936507937,
                     child: AutoSizeText(
-                      widget.ovrContinue ?? 'Continue',
-                      style: TextStyle(
+                      widget.ovrContinue ?? GeniusWalletText.btnContinue,
+                      style: const TextStyle(
                         fontFamily: 'Roboto',
                         fontSize: 11.0,
                         fontWeight: FontWeight.w400,
                         letterSpacing: 0.13750000298023224,
-                        color: Colors.white,
+                        color: GeniusWalletColors.btnTextDisabled,
                       ),
                       textAlign: TextAlign.center,
                     )),

--- a/lib/widgets/components/continue_button/isactive_false.g.dart
+++ b/lib/widgets/components/continue_button/isactive_false.g.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
+import 'package:genius_wallet/theme/genius_wallet_font_size.dart';
 import 'package:genius_wallet/theme/genius_wallet_text.dart';
 import 'package:genius_wallet/widgets/components/custom/isactive_false_custom.dart';
 import 'package:auto_size_text/auto_size_text.dart';
@@ -63,7 +64,7 @@ class _IsactiveFalse extends State<IsactiveFalse> {
                       widget.ovrContinue ?? GeniusWalletText.btnContinue,
                       style: const TextStyle(
                         fontFamily: 'Roboto',
-                        fontSize: 11.0,
+                        fontSize: GeniusWalletFontSize.medium,
                         fontWeight: FontWeight.w400,
                         letterSpacing: 0.13750000298023224,
                         color: GeniusWalletColors.btnTextDisabled,

--- a/lib/widgets/components/continue_button/isactive_true.g.dart
+++ b/lib/widgets/components/continue_button/isactive_true.g.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
+import 'package:genius_wallet/theme/genius_wallet_font_size.dart';
 import 'package:genius_wallet/theme/genius_wallet_gradient.dart';
 import 'package:genius_wallet/theme/genius_wallet_text.dart';
 import 'package:genius_wallet/widgets/components/custom/isactive_true_custom.dart';
@@ -64,7 +65,7 @@ class _IsactiveTrue extends State<IsactiveTrue> {
                       widget.ovrContinue ?? GeniusWalletText.btnContinue,
                       style: const TextStyle(
                         fontFamily: 'Roboto',
-                        fontSize: 11.0,
+                        fontSize: GeniusWalletFontSize.medium,
                         fontWeight: FontWeight.w400,
                         letterSpacing: 0.13750000298023224,
                         color: GeniusWalletColors.btnText,

--- a/lib/widgets/components/continue_button/isactive_true.g.dart
+++ b/lib/widgets/components/continue_button/isactive_true.g.dart
@@ -5,6 +5,8 @@
 // *********************************************************************************
 
 import 'package:flutter/material.dart';
+import 'package:genius_wallet/theme/genius_wallet_gradient.dart';
+import 'package:genius_wallet/theme/genius_wallet_text.dart';
 import 'package:genius_wallet/widgets/components/custom/isactive_true_custom.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 
@@ -26,7 +28,7 @@ class _IsactiveTrue extends State<IsactiveTrue> {
   @override
   Widget build(BuildContext context) {
     return Container(
-        decoration: BoxDecoration(),
+        decoration: const BoxDecoration(),
         child: IsactiveTrueCustom(
             child: Stack(children: [
           Positioned(
@@ -44,20 +46,8 @@ class _IsactiveTrue extends State<IsactiveTrue> {
                   height: widget.constraints.maxHeight * 1.0,
                   width: widget.constraints.maxWidth * 1.0,
                   decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin:
-                          Alignment(-0.8444444484172715, -2.945831951706168e-7),
-                      end: Alignment(0.9047618681449168, 0.999998242777302),
-                      colors: <Color>[
-                        Color(0xff00a9fe),
-                        Color(0xff00f4a8),
-                      ],
-                      stops: [
-                        0.0,
-                        1.0,
-                      ],
-                      tileMode: TileMode.clamp,
-                    ),
+                    borderRadius: BorderRadius.circular(48),
+                    gradient: GeniusWalletGradient.greenBlueGreenGradient,
                   ),
                 ),
               ),
@@ -70,8 +60,8 @@ class _IsactiveTrue extends State<IsactiveTrue> {
                     height: widget.constraints.maxHeight * 0.2826086956521739,
                     width: widget.constraints.maxWidth * 0.27936507936507937,
                     child: AutoSizeText(
-                      widget.ovrContinue ?? 'Continue',
-                      style: TextStyle(
+                      widget.ovrContinue ?? GeniusWalletText.btnContinue,
+                      style: const TextStyle(
                         fontFamily: 'Roboto',
                         fontSize: 11.0,
                         fontWeight: FontWeight.w400,

--- a/lib/widgets/components/continue_button/isactive_true.g.dart
+++ b/lib/widgets/components/continue_button/isactive_true.g.dart
@@ -5,6 +5,7 @@
 // *********************************************************************************
 
 import 'package:flutter/material.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
 import 'package:genius_wallet/theme/genius_wallet_gradient.dart';
 import 'package:genius_wallet/theme/genius_wallet_text.dart';
 import 'package:genius_wallet/widgets/components/custom/isactive_true_custom.dart';
@@ -66,7 +67,7 @@ class _IsactiveTrue extends State<IsactiveTrue> {
                         fontSize: 11.0,
                         fontWeight: FontWeight.w400,
                         letterSpacing: 0.13750000298023224,
-                        color: Colors.white,
+                        color: GeniusWalletColors.btnText,
                       ),
                       textAlign: TextAlign.center,
                     )),

--- a/lib/widgets/components/custom/wallet_agreement_custom.dart
+++ b/lib/widgets/components/custom/wallet_agreement_custom.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
 
 class WalletAgreementCustom extends StatefulWidget {
   final Widget? child;

--- a/lib/widgets/components/custom/wallet_agreement_custom.dart
+++ b/lib/widgets/components/custom/wallet_agreement_custom.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
 
 class WalletAgreementCustom extends StatefulWidget {
   final Widget? child;

--- a/lib/widgets/components/recoveryword.g.dart
+++ b/lib/widgets/components/recoveryword.g.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
 
 class Recoveryword extends StatefulWidget {
   final BoxConstraints constraints;
@@ -25,7 +26,7 @@ class _Recoveryword extends State<Recoveryword> {
   @override
   Widget build(BuildContext context) {
     return Container(
-        decoration: BoxDecoration(),
+        decoration: const BoxDecoration(),
         child: Stack(children: [
           Positioned(
             left: 0,
@@ -34,7 +35,7 @@ class _Recoveryword extends State<Recoveryword> {
             height: widget.constraints.maxHeight * 1.0,
             child: Container(
                 clipBehavior: Clip.hardEdge,
-                decoration: BoxDecoration(),
+                decoration: const BoxDecoration(),
                 child: Stack(children: [
                   Positioned(
                     left: 0,
@@ -45,9 +46,10 @@ class _Recoveryword extends State<Recoveryword> {
                       height: widget.constraints.maxHeight * 1.0,
                       width: widget.constraints.maxWidth * 1.0,
                       decoration: BoxDecoration(
-                        borderRadius: BorderRadius.all(Radius.circular(3.0)),
+                        borderRadius:
+                            const BorderRadius.all(Radius.circular(48)),
                         border: Border.all(
-                          color: Color(0xff00efae),
+                          color: GeniusWalletColors.lightGreenPrimary,
                           width: 1.0,
                         ),
                       ),
@@ -58,13 +60,13 @@ class _Recoveryword extends State<Recoveryword> {
                     width: widget.constraints.maxWidth * 0.784,
                     top: widget.constraints.maxHeight * 0.286,
                     height: widget.constraints.maxHeight * 0.464,
-                    child: Container(
+                    child: SizedBox(
                         height:
                             widget.constraints.maxHeight * 0.4642866853983504,
                         width: widget.constraints.maxWidth * 0.7843116554054054,
                         child: AutoSizeText(
                           widget.ovrWord ?? '1 limb',
-                          style: TextStyle(
+                          style: const TextStyle(
                             fontFamily: 'Roboto',
                             fontSize: 16.0,
                             fontWeight: FontWeight.w300,

--- a/lib/widgets/components/registration_header.g.dart
+++ b/lib/widgets/components/registration_header.g.dart
@@ -54,6 +54,26 @@ class _RegistrationHeader extends State<RegistrationHeader> {
                 ),
               ),
               Positioned(
+                left: 30.0,
+                right: 30.0,
+                top: 100.0,
+                height: 32.0,
+                child: Container(
+                    height: 32.0,
+                    width: widget.constraints.maxWidth * 0.84,
+                    child: AutoSizeText(
+                      widget.ovrSubtitle ??
+                          'In the next step you will see 12 words that allows you to recover a wallet.',
+                      style: const TextStyle(
+                        fontFamily: 'Roboto',
+                        fontSize: 14.0,
+                        fontWeight: FontWeight.w400,
+                        letterSpacing: 0.13750000298023224,
+                        color: Colors.white,
+                      ),
+                    )),
+              ),
+              Positioned(
                 left: 74.0,
                 right: 74.0,
                 top: 16,

--- a/lib/widgets/components/registration_header.g.dart
+++ b/lib/widgets/components/registration_header.g.dart
@@ -93,13 +93,6 @@ class _RegistrationHeader extends State<RegistrationHeader> {
               ),
             ]),
           ),
-          Positioned(
-            left: 30,
-            width: widget.constraints.maxWidth * 0.9,
-            top: 100,
-            height: widget.constraints.maxHeight * 1.0,
-            child: const Text(GeniusWalletText.helpTextWalletBackup),
-          )
         ]));
   }
 

--- a/lib/widgets/components/registration_header.g.dart
+++ b/lib/widgets/components/registration_header.g.dart
@@ -6,6 +6,9 @@
 
 import 'package:flutter/material.dart';
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
+import 'package:genius_wallet/theme/genius_wallet_font_size.dart';
+import 'package:genius_wallet/theme/genius_wallet_text.dart';
 import 'package:genius_wallet/widgets/components/custom/genius_back_button_custom.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:genius_wallet/widgets/components/genius_back_button.g.dart';
@@ -30,7 +33,7 @@ class _RegistrationHeader extends State<RegistrationHeader> {
   @override
   Widget build(BuildContext context) {
     return Container(
-        decoration: BoxDecoration(),
+        decoration: const BoxDecoration(),
         child: Stack(children: [
           Positioned(
             left: 0,
@@ -42,49 +45,25 @@ class _RegistrationHeader extends State<RegistrationHeader> {
                 left: 0,
                 right: 0,
                 top: 0,
-                height: 190.0,
+                height: 56,
                 child: Container(
-                  height: 190.0,
                   width: widget.constraints.maxWidth * 1.0,
-                  decoration: BoxDecoration(
-                    color: Color(0xff0068ef),
+                  decoration: const BoxDecoration(
+                    color: GeniusWalletColors.grayPrimary,
                   ),
                 ),
               ),
               Positioned(
-                left: 30.0,
-                right: 30.0,
-                top: 100.0,
-                height: 32.0,
-                child: Container(
-                    height: 32.0,
-                    width: widget.constraints.maxWidth * 0.84,
-                    child: AutoSizeText(
-                      widget.ovrSubtitle ??
-                          'In the next step you will see 12 words that allows you to recover a wallet.',
-                      style: TextStyle(
-                        fontFamily: 'Roboto',
-                        fontSize: 14.0,
-                        fontWeight: FontWeight.w400,
-                        letterSpacing: 0.13750000298023224,
-                        color: Colors.white,
-                      ),
-                      textAlign: TextAlign.center,
-                    )),
-              ),
-              Positioned(
                 left: 74.0,
                 right: 74.0,
-                top: 57.0,
-                height: 23.0,
-                child: Container(
-                    height: 23.0,
+                top: 16,
+                child: SizedBox(
                     width: widget.constraints.maxWidth * 0.6053333333333333,
                     child: AutoSizeText(
-                      widget.ovrTitle ?? 'Back up your wallet now!',
-                      style: TextStyle(
+                      widget.ovrTitle ?? GeniusWalletText.titleWalletBackup,
+                      style: const TextStyle(
                         fontFamily: 'Roboto',
-                        fontSize: 20.0,
+                        fontSize: GeniusWalletFontSize.title,
                         fontWeight: FontWeight.w700,
                         letterSpacing: 0.13750000298023224,
                         color: Colors.white,
@@ -95,7 +74,7 @@ class _RegistrationHeader extends State<RegistrationHeader> {
               Positioned(
                 left: 30.0,
                 width: 10.0,
-                top: 22.0,
+                top: 20.0,
                 height: 18.0,
                 child: GeniusBackButtonCustom(
                     child: LayoutBuilder(builder: (context, constraints) {
@@ -114,6 +93,13 @@ class _RegistrationHeader extends State<RegistrationHeader> {
               ),
             ]),
           ),
+          Positioned(
+            left: 30,
+            width: widget.constraints.maxWidth * 0.9,
+            top: 100,
+            height: widget.constraints.maxHeight * 1.0,
+            child: const Text(GeniusWalletText.helpTextWalletBackup),
+          )
         ]));
   }
 


### PR DESCRIPTION
This PR updates the wallet back up screen to match the latest figma.

Following the theme pattern:
- sets the checkbox theme in the main file

https://www.figma.com/file/7T7GiBEszjus4tpyOAiPaI/GNUS-FInal-Build?type=design&node-id=206-7390&mode=dev

<img width="1256" alt="wallet_backup_diff png" src="https://github.com/GeniusVentures/GeniusWallet/assets/48568237/56fe2433-4e22-403b-804d-6f9d92a12df6">
