### PR TITLE
Adds Events, News mock services, responsive grid / improvements

### DIFF
--- a/lib/app/bloc/overlay/navigation_overlay_state.dart
+++ b/lib/app/bloc/overlay/navigation_overlay_state.dart
@@ -22,14 +22,15 @@ class NavigationOverlayState {
   }
 }
 
+// This order determines what screen to select on when clicking on the navigation rail, this order must match the order in `destinations`
 enum NavigationScreen {
   dashboard,
   wallets,
   transactions,
   trade,
   markets,
-  events,
   calculator,
   news,
+  events,
   settings
 }

--- a/lib/app/utils/breakpoints.dart
+++ b/lib/app/utils/breakpoints.dart
@@ -17,6 +17,10 @@ abstract class GeniusBreakpoints {
     return MediaQuery.of(context).size.width > small;
   }
 
+  static bool isNativeApp(BuildContext context) {
+    return getPlaform(context) == Platforms.mobile;
+  }
+
   static Platforms getPlaform(BuildContext context) {
     if (kIsWeb) {
       return MediaQuery.of(context).size.width >= small

--- a/lib/app/widgets/desktop_container.dart
+++ b/lib/app/widgets/desktop_container.dart
@@ -38,6 +38,7 @@ class DesktopContainer extends StatelessWidget {
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
                               Wrap(
+                                crossAxisAlignment: WrapCrossAlignment.center,
                                 spacing: 40,
                                 children: [
                                   Wrap(
@@ -66,9 +67,11 @@ class DesktopContainer extends StatelessWidget {
                                             label: const Text('Back'))
                                     ],
                                   ),
-                                  const SizedBox(
-                                      width: 300,
-                                      child: SearchBar(
+                                  SizedBox(
+                                      height: 50,
+                                      width: MediaQuery.of(context).size.width *
+                                          .3,
+                                      child: const SearchBar(
                                         hintText: 'Search ...',
                                         trailing: [
                                           Icon(

--- a/lib/app/widgets/desktop_container.dart
+++ b/lib/app/widgets/desktop_container.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:genius_wallet/app/utils/breakpoints.dart';
 import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
 import 'package:genius_wallet/theme/genius_wallet_consts.dart';
 import 'package:genius_wallet/theme/genius_wallet_text.dart';
@@ -17,13 +18,19 @@ class DesktopContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    double horizontalPadding = GeniusBreakpoints.useDesktopLayout(context)
+        ? GeniusWalletConsts.horizontalPadding
+        : 20;
     return Scaffold(
         backgroundColor: GeniusWalletColors.deepBlueTertiary,
         body: SingleChildScrollView(
             child: SafeArea(
                 child: Padding(
-                    padding: const EdgeInsets.only(
-                        left: 80, top: 40, right: 40, bottom: 40),
+                    padding: EdgeInsets.only(
+                        left: horizontalPadding,
+                        top: 40,
+                        right: horizontalPadding,
+                        bottom: 40),
                     child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [

--- a/lib/app/widgets/overlay/desktop_overlay.dart
+++ b/lib/app/widgets/overlay/desktop_overlay.dart
@@ -33,18 +33,26 @@ class _DesktopSideRail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final destinations = _buildDestinations();
-    return NavigationRail(
-      destinations: destinations,
-      onDestinationSelected:
-          context.read<NavigationOverlayCubit>().navigationTapped,
-      selectedIndex:
-          context.watch<NavigationOverlayCubit>().state.selectedScreen.index,
-      leading: Padding(
-        padding: const EdgeInsets.only(top: 50, bottom: 30),
-        child: Image.asset('assets/images/geniusappbarlogo.png',
-            package: 'genius_wallet'),
-      ),
-    );
+    return SingleChildScrollView(
+        child: ConstrainedBox(
+            constraints:
+                BoxConstraints(minHeight: MediaQuery.of(context).size.height),
+            child: IntrinsicHeight(
+                child: NavigationRail(
+              destinations: destinations,
+              onDestinationSelected:
+                  context.read<NavigationOverlayCubit>().navigationTapped,
+              selectedIndex: context
+                  .watch<NavigationOverlayCubit>()
+                  .state
+                  .selectedScreen
+                  .index,
+              leading: Padding(
+                padding: const EdgeInsets.only(top: 40, bottom: 20),
+                child: Image.asset('assets/images/geniusappbarlogo.png',
+                    package: 'genius_wallet'),
+              ),
+            ))));
   }
 
   List<NavigationRailDestination> _buildDestinations() {

--- a/lib/app/widgets/overlay/destinations.dart
+++ b/lib/app/widgets/overlay/destinations.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:genius_wallet/app/widgets/overlay/genius_destination.dart';
 
+// This order must match whats in `navigation_overlay_state/NavigationScreen` enum
 class GeniusTabDestinations {
   static final destinations = [
     const GeniusDestination(

--- a/lib/app/widgets/overlay/destinations.dart
+++ b/lib/app/widgets/overlay/destinations.dart
@@ -31,12 +31,6 @@ class GeniusTabDestinations {
         icon: Icon(Icons.stacked_line_chart),
         selectedIcon: Icon(Icons.stacked_line_chart)),
     const GeniusDestination(
-      destination: '/events',
-      label: Text('Events'),
-      icon: Icon(Icons.calendar_month),
-      selectedIcon: Icon(Icons.calendar_month),
-    ),
-    const GeniusDestination(
       destination: '/calculator',
       label: Text('Calculator'),
       icon: Icon(Icons.calculate),
@@ -45,8 +39,14 @@ class GeniusTabDestinations {
     const GeniusDestination(
       destination: '/news',
       label: Text('News'),
-      icon: Icon(Icons.newspaper),
-      selectedIcon: Icon(Icons.newspaper),
+      icon: Icon(Icons.calendar_month),
+      selectedIcon: Icon(Icons.calendar_month),
+    ),
+    const GeniusDestination(
+      destination: '/events',
+      label: Text('Events'),
+      icon: Icon(Icons.library_books),
+      selectedIcon: Icon(Icons.library_books),
     ),
   ];
 }

--- a/lib/app/widgets/overlay/responsive_overlay.dart
+++ b/lib/app/widgets/overlay/responsive_overlay.dart
@@ -6,7 +6,9 @@ import 'package:genius_wallet/app/utils/breakpoints.dart';
 import 'package:genius_wallet/app/widgets/overlay/desktop_overlay.dart';
 import 'package:genius_wallet/app/widgets/overlay/mobile_overlay.dart';
 import 'package:genius_wallet/calculator/view/calculator_screen.dart';
+import 'package:genius_wallet/dashboard/events/view/events_screen.dart';
 import 'package:genius_wallet/dashboard/home/view/home_screen.dart';
+import 'package:genius_wallet/dashboard/news/view/news_screen.dart';
 import 'package:genius_wallet/dashboard/trade/view/trade_screen.dart';
 import 'package:genius_wallet/dashboard/transactions/view/transactions_screen.dart';
 import 'package:genius_wallet/dashboard/wallets/view/wallets_screen.dart';
@@ -37,13 +39,13 @@ class ResponsiveOverlay extends StatelessWidget {
             child = const TransactionsScreen();
             break;
           case NavigationScreen.news:
-            child = const Center(child: Text('Coming soon'));
+            child = const NewsScreen();
             break;
           case NavigationScreen.markets:
             child = const MarketsScreen();
             break;
           case NavigationScreen.events:
-            child = const Center(child: Text('Coming soon'));
+            child = const EventsScreen();
             break;
           case NavigationScreen.calculator:
             child = const CalculatorScreen();

--- a/lib/app/widgets/responsive_grid.dart
+++ b/lib/app/widgets/responsive_grid.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:genius_wallet/app/utils/breakpoints.dart';
+
+class ResponsiveGrid extends StatelessWidget {
+  final List<Widget> children;
+  const ResponsiveGrid({Key? key, this.children = const []}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    double screenWidth = MediaQuery.of(context).size.width;
+    int axisCount = screenWidth < 750 || GeniusBreakpoints.isNativeApp(context)
+        ? 1
+        : screenWidth < 1000
+            ? 2
+            : screenWidth < 1400
+                ? 3
+                : 4;
+    return GridView.count(
+        shrinkWrap: true,
+        crossAxisCount: axisCount,
+        mainAxisSpacing: 12,
+        crossAxisSpacing: 12,
+        children: children);
+  }
+}

--- a/lib/dashboard/events/view/bloc/events_cubit.dart
+++ b/lib/dashboard/events/view/bloc/events_cubit.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:genius_api/genius_api.dart';
+import 'package:genius_wallet/dashboard/events/view/bloc/events_state.dart';
+
+class EventsCubit extends Cubit<EventsState> {
+  GeniusApi api;
+  EventsCubit({
+    required this.api,
+  }) : super(EventsState());
+
+  Future<void> loadEvents() async {
+    emit(state.copyWith(eventsLoadingStatus: EventsStatus.loading));
+
+    try {
+      final events = await api.getEvents();
+
+      emit(state.copyWith(
+        events: events,
+        eventsLoadingStatus: EventsStatus.loaded,
+      ));
+    } catch (e) {
+      emit(state.copyWith(eventsLoadingStatus: EventsStatus.error));
+    }
+  }
+}

--- a/lib/dashboard/events/view/bloc/events_state.dart
+++ b/lib/dashboard/events/view/bloc/events_state.dart
@@ -1,0 +1,24 @@
+import 'package:genius_api/models/events.dart';
+
+class EventsState {
+  EventsStatus eventsLoadingStatus;
+
+  List<Events> events;
+
+  EventsState({
+    this.eventsLoadingStatus = EventsStatus.initial,
+    this.events = const [],
+  });
+
+  EventsState copyWith({
+    EventsStatus? eventsLoadingStatus,
+    List<Events>? events,
+  }) {
+    return EventsState(
+      eventsLoadingStatus: eventsLoadingStatus ?? this.eventsLoadingStatus,
+      events: events ?? this.events,
+    );
+  }
+}
+
+enum EventsStatus { initial, loading, loaded, error }

--- a/lib/dashboard/events/view/events_screen.dart
+++ b/lib/dashboard/events/view/events_screen.dart
@@ -6,6 +6,7 @@ import 'package:genius_wallet/app/screens/loading_screen.dart';
 import 'package:genius_wallet/app/utils/breakpoints.dart';
 import 'package:genius_wallet/app/widgets/app_screen_view.dart';
 import 'package:genius_wallet/app/widgets/desktop_container.dart';
+import 'package:genius_wallet/app/widgets/responsive_grid.dart';
 import 'package:genius_wallet/dashboard/events/view/bloc/events_cubit.dart';
 import 'package:genius_wallet/dashboard/events/view/bloc/events_state.dart';
 import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
@@ -44,23 +45,10 @@ class Desktop extends StatelessWidget {
           if (state.eventsLoadingStatus == EventsStatus.loading) {
             return const LoadingScreen();
           }
-          double screenWidth = MediaQuery.of(context).size.width;
-          int axisCount =
-              screenWidth < 750 || GeniusBreakpoints.isNativeApp(context)
-                  ? 1
-                  : screenWidth < 1000
-                      ? 2
-                      : screenWidth < 1400
-                          ? 3
-                          : 4;
-          return GridView.count(
-              shrinkWrap: true,
-              crossAxisCount: axisCount,
-              mainAxisSpacing: 4,
-              crossAxisSpacing: 4,
-              children: [
-                for (var event in state.events) EventsCard(event: event)
-              ]);
+
+          return ResponsiveGrid(children: [
+            for (var event in state.events) EventsCard(event: event)
+          ]);
         }));
   }
 }

--- a/lib/dashboard/events/view/events_screen.dart
+++ b/lib/dashboard/events/view/events_screen.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:genius_api/genius_api.dart';
+import 'package:genius_wallet/app/utils/breakpoints.dart';
+import 'package:genius_wallet/app/widgets/app_screen_view.dart';
+import 'package:genius_wallet/app/widgets/desktop_container.dart';
+import 'package:genius_wallet/dashboard/events/view/bloc/events_cubit.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
+import 'package:genius_wallet/widgets/components/date_selector.g.dart';
+import 'package:genius_wallet/widgets/components/transaction_filter.g.dart';
+
+class EventsScreen extends StatelessWidget {
+  const EventsScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (GeniusBreakpoints.useDesktopLayout(context)) {
+      return BlocProvider(
+        create: (context) =>
+            EventsCubit(api: context.read<GeniusApi>())..loadEvents(),
+        child: const Desktop(),
+      );
+    }
+    return AppScreenView(
+      body: BlocProvider(
+        create: (context) =>
+            EventsCubit(api: context.read<GeniusApi>())..loadEvents(),
+        child: const Mobile(),
+      ),
+    );
+  }
+}
+
+class Desktop extends StatelessWidget {
+  const Desktop({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return DesktopContainer(
+      title: 'Events',
+      child: Column(
+        children: [
+          const SizedBox(height: 30),
+          const SizedBox(height: 50),
+          SizedBox(
+            height: 20,
+            child: LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
+                return TransactionFilter(constraints);
+              },
+            ),
+          ),
+          const SizedBox(height: 50),
+        ],
+      ),
+    );
+  }
+}
+
+class Mobile extends StatelessWidget {
+  const Mobile({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: GeniusWalletColors.deepBlueTertiary,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 30),
+          child: Column(
+            children: [
+              const SizedBox(height: 30),
+              const SizedBox(height: 30),
+              SizedBox(
+                height: 30,
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    return DateSelector(constraints);
+                  },
+                ),
+              ),
+              const SizedBox(height: 30),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/dashboard/news/view/bloc/news_cubit.dart
+++ b/lib/dashboard/news/view/bloc/news_cubit.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:genius_api/genius_api.dart';
+import 'package:genius_wallet/dashboard/news/view/bloc/news_state.dart';
+
+class NewsCubit extends Cubit<NewsState> {
+  GeniusApi api;
+  NewsCubit({
+    required this.api,
+  }) : super(NewsState());
+
+  Future<void> loadNews() async {
+    emit(state.copyWith(newsLoadingStatus: NewsStatus.loading));
+
+    try {
+      final news = await api.getNews();
+
+      emit(state.copyWith(
+        news: news,
+        newsLoadingStatus: NewsStatus.loaded,
+      ));
+    } catch (e) {
+      emit(state.copyWith(newsLoadingStatus: NewsStatus.error));
+    }
+  }
+}

--- a/lib/dashboard/news/view/bloc/news_state.dart
+++ b/lib/dashboard/news/view/bloc/news_state.dart
@@ -1,0 +1,24 @@
+import 'package:genius_api/models/news.dart';
+
+class NewsState {
+  NewsStatus newsLoadingStatus;
+
+  List<News> news;
+
+  NewsState({
+    this.newsLoadingStatus = NewsStatus.initial,
+    this.news = const [],
+  });
+
+  NewsState copyWith({
+    NewsStatus? newsLoadingStatus,
+    List<News>? news,
+  }) {
+    return NewsState(
+      newsLoadingStatus: newsLoadingStatus ?? this.newsLoadingStatus,
+      news: news ?? this.news,
+    );
+  }
+}
+
+enum NewsStatus { initial, loading, loaded, error }

--- a/lib/dashboard/news/view/news_screen.dart
+++ b/lib/dashboard/news/view/news_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:genius_api/genius_api.dart';
+import 'package:genius_wallet/app/screens/loading_screen.dart';
+import 'package:genius_wallet/app/utils/breakpoints.dart';
+import 'package:genius_wallet/app/widgets/app_screen_view.dart';
+import 'package:genius_wallet/app/widgets/desktop_container.dart';
+import 'package:genius_wallet/dashboard/news/view/bloc/news_cubit.dart';
+import 'package:genius_wallet/dashboard/news/view/bloc/news_state.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
+import 'package:genius_wallet/theme/genius_wallet_consts.dart';
+import 'package:genius_wallet/widgets/components/date_selector.g.dart';
+import 'package:genius_wallet/widgets/components/transaction_filter.g.dart';
+
+class NewsScreen extends StatelessWidget {
+  const NewsScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (GeniusBreakpoints.useDesktopLayout(context)) {
+      return BlocProvider(
+        create: (context) =>
+            NewsCubit(api: context.read<GeniusApi>())..loadNews(),
+        child: const Desktop(),
+      );
+    }
+    return AppScreenView(
+      body: BlocProvider(
+        create: (context) =>
+            NewsCubit(api: context.read<GeniusApi>())..loadNews(),
+        child: const Mobile(),
+      ),
+    );
+  }
+}
+
+class Desktop extends StatelessWidget {
+  const Desktop({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return DesktopContainer(
+        title: 'Crypto News',
+        child: BlocBuilder<NewsCubit, NewsState>(builder: (context, state) {
+          if (state.newsLoadingStatus == NewsStatus.loading) {
+            return const LoadingScreen();
+          }
+          return Wrap(
+              spacing: GeniusWalletConsts.itemSpacing,
+              runSpacing: GeniusWalletConsts.itemSpacing,
+              children: [
+                for (var news in state.news)
+                  SizedBox(
+                    height: 350,
+                    width: 350,
+                    child: LayoutBuilder(
+                      builder:
+                          (BuildContext context, BoxConstraints constraints) {
+                        return Text(news.headline);
+                      },
+                    ),
+                  ),
+              ]);
+        }));
+  }
+}
+
+class Mobile extends StatelessWidget {
+  const Mobile({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: GeniusWalletColors.deepBlueTertiary,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 30),
+          child: Column(
+            children: [
+              const SizedBox(height: 30),
+              const SizedBox(height: 30),
+              SizedBox(
+                height: 30,
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    return DateSelector(constraints);
+                  },
+                ),
+              ),
+              const SizedBox(height: 30),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/dashboard/news/view/news_screen.dart
+++ b/lib/dashboard/news/view/news_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:genius_api/genius_api.dart';
+import 'package:genius_api/models/news.dart';
 import 'package:genius_wallet/app/screens/loading_screen.dart';
 import 'package:genius_wallet/app/utils/breakpoints.dart';
 import 'package:genius_wallet/app/widgets/app_screen_view.dart';
@@ -9,8 +10,6 @@ import 'package:genius_wallet/dashboard/news/view/bloc/news_cubit.dart';
 import 'package:genius_wallet/dashboard/news/view/bloc/news_state.dart';
 import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
 import 'package:genius_wallet/theme/genius_wallet_consts.dart';
-import 'package:genius_wallet/widgets/components/date_selector.g.dart';
-import 'package:genius_wallet/widgets/components/transaction_filter.g.dart';
 
 class NewsScreen extends StatelessWidget {
   const NewsScreen({Key? key}) : super(key: key);
@@ -48,19 +47,7 @@ class Desktop extends StatelessWidget {
           return Wrap(
               spacing: GeniusWalletConsts.itemSpacing,
               runSpacing: GeniusWalletConsts.itemSpacing,
-              children: [
-                for (var news in state.news)
-                  SizedBox(
-                    height: 350,
-                    width: 350,
-                    child: LayoutBuilder(
-                      builder:
-                          (BuildContext context, BoxConstraints constraints) {
-                        return Text(news.headline);
-                      },
-                    ),
-                  ),
-              ]);
+              children: [for (var news in state.news) NewsCard(news: news)]);
         }));
   }
 }
@@ -74,24 +61,39 @@ class Mobile extends StatelessWidget {
       backgroundColor: GeniusWalletColors.deepBlueTertiary,
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 30),
-          child: Column(
-            children: [
-              const SizedBox(height: 30),
-              const SizedBox(height: 30),
-              SizedBox(
-                height: 30,
-                child: LayoutBuilder(
-                  builder: (context, constraints) {
-                    return DateSelector(constraints);
-                  },
-                ),
-              ),
-              const SizedBox(height: 30),
-            ],
-          ),
-        ),
+            padding: const EdgeInsets.symmetric(horizontal: 30),
+            child: BlocBuilder<NewsCubit, NewsState>(builder: (context, state) {
+              if (state.newsLoadingStatus == NewsStatus.loading) {
+                return const LoadingScreen();
+              }
+              return Wrap(
+                  spacing: GeniusWalletConsts.itemSpacing,
+                  runSpacing: GeniusWalletConsts.itemSpacing,
+                  children: [
+                    for (var news in state.news)
+                      SizedBox(
+                        height: 350,
+                        width: 350,
+                        child: LayoutBuilder(
+                          builder: (BuildContext context,
+                              BoxConstraints constraints) {
+                            return Text(news.body);
+                          },
+                        ),
+                      ),
+                  ]);
+            })),
       ),
     );
+  }
+}
+
+class NewsCard extends StatelessWidget {
+  final News news;
+  const NewsCard({Key? key, required this.news}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(child: Text(news.date));
   }
 }

--- a/lib/dashboard/news/view/news_screen.dart
+++ b/lib/dashboard/news/view/news_screen.dart
@@ -77,7 +77,7 @@ class Mobile extends StatelessWidget {
                         child: LayoutBuilder(
                           builder: (BuildContext context,
                               BoxConstraints constraints) {
-                            return Text(news.body);
+                            return Text(news.body ?? '');
                           },
                         ),
                       ),
@@ -94,6 +94,6 @@ class NewsCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(child: Text(news.date));
+    return SizedBox(child: Text(news.date ?? ''));
   }
 }

--- a/lib/dashboard/news/view/news_screen.dart
+++ b/lib/dashboard/news/view/news_screen.dart
@@ -6,6 +6,7 @@ import 'package:genius_wallet/app/screens/loading_screen.dart';
 import 'package:genius_wallet/app/utils/breakpoints.dart';
 import 'package:genius_wallet/app/widgets/app_screen_view.dart';
 import 'package:genius_wallet/app/widgets/desktop_container.dart';
+import 'package:genius_wallet/app/widgets/responsive_grid.dart';
 import 'package:genius_wallet/dashboard/news/view/bloc/news_cubit.dart';
 import 'package:genius_wallet/dashboard/news/view/bloc/news_state.dart';
 import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
@@ -66,22 +67,19 @@ class Mobile extends StatelessWidget {
               if (state.newsLoadingStatus == NewsStatus.loading) {
                 return const LoadingScreen();
               }
-              return Wrap(
-                  spacing: GeniusWalletConsts.itemSpacing,
-                  runSpacing: GeniusWalletConsts.itemSpacing,
-                  children: [
-                    for (var news in state.news)
-                      SizedBox(
-                        height: 350,
-                        width: 350,
-                        child: LayoutBuilder(
-                          builder: (BuildContext context,
-                              BoxConstraints constraints) {
-                            return Text(news.body ?? '');
-                          },
-                        ),
-                      ),
-                  ]);
+              return ResponsiveGrid(children: [
+                for (var news in state.news)
+                  SizedBox(
+                    height: 350,
+                    width: 350,
+                    child: LayoutBuilder(
+                      builder:
+                          (BuildContext context, BoxConstraints constraints) {
+                        return Text(news.body ?? '');
+                      },
+                    ),
+                  ),
+              ]);
             })),
       ),
     );

--- a/lib/dashboard/transactions/view/transactions_screen.dart
+++ b/lib/dashboard/transactions/view/transactions_screen.dart
@@ -23,7 +23,7 @@ class TransactionsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (GeniusBreakpoints.useDesktopLayout(context)) {
+    if (!GeniusBreakpoints.isNativeApp(context)) {
       return const Desktop();
     }
     return const Mobile();
@@ -70,8 +70,9 @@ class Mobile extends StatelessWidget {
     return Scaffold(
       backgroundColor: GeniusWalletColors.deepBlueTertiary,
       body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 30),
+          child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 30),
+        child: SingleChildScrollView(
           child: Column(
             children: [
               const TransactionsToggle(),
@@ -93,7 +94,7 @@ class Mobile extends StatelessWidget {
             ],
           ),
         ),
-      ),
+      )),
     );
   }
 }

--- a/lib/dashboard/wallets/view/wallets_screen.dart
+++ b/lib/dashboard/wallets/view/wallets_screen.dart
@@ -5,6 +5,7 @@ import 'package:genius_wallet/app/bloc/app_bloc.dart';
 import 'package:genius_wallet/app/utils/breakpoints.dart';
 import 'package:genius_wallet/app/utils/wallet_utils.dart';
 import 'package:genius_wallet/app/widgets/desktop_container.dart';
+import 'package:genius_wallet/app/widgets/responsive_grid.dart';
 import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
 import 'package:genius_wallet/theme/genius_wallet_consts.dart';
 import 'package:genius_wallet/theme/genius_wallet_text.dart';
@@ -17,7 +18,7 @@ class WalletsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (GeniusBreakpoints.useDesktopLayout(context)) {
+    if (!GeniusBreakpoints.isNativeApp(context)) {
       return const Desktop();
     }
     return const Mobile();
@@ -36,61 +37,57 @@ class Desktop extends StatelessWidget {
       child: BlocBuilder<AppBloc, AppState>(
         builder: (context, state) {
           if (state.wallets.isNotEmpty) {
-            return Wrap(
-                spacing: GeniusWalletConsts.itemSpacing,
-                runSpacing: GeniusWalletConsts.itemSpacing,
-                children: [
-                  for (var wallet in state.wallets)
-                    SizedBox(
-                      height: 350,
-                      width: 350,
-                      child: LayoutBuilder(
-                        builder:
-                            (BuildContext context, BoxConstraints constraints) {
-                          //TODO: override trendline here
-                          final trendLine = SvgPicture.asset(
-                            'assets/images/trendline.svg',
-                            package: 'genius_wallet',
-                            fit: BoxFit.fill,
-                          );
-                          String timestamp = '';
-                          String transactionValue = '';
-                          String transactionId =
-                              'No transactions for this wallet';
-                          if (wallet.transactions.isNotEmpty) {
-                            // TODO: May need to actually compare dates to get latest
-                            final lastTransaction = wallet.transactions.last;
+            return ResponsiveGrid(children: [
+              for (var wallet in state.wallets)
+                SizedBox(
+                  height: 350,
+                  width: 350,
+                  child: LayoutBuilder(
+                    builder:
+                        (BuildContext context, BoxConstraints constraints) {
+                      //TODO: override trendline here
+                      final trendLine = SvgPicture.asset(
+                        'assets/images/trendline.svg',
+                        package: 'genius_wallet',
+                        fit: BoxFit.fill,
+                      );
+                      String timestamp = '';
+                      String transactionValue = '';
+                      String transactionId = 'No transactions for this wallet';
+                      if (wallet.transactions.isNotEmpty) {
+                        // TODO: May need to actually compare dates to get latest
+                        final lastTransaction = wallet.transactions.last;
 
-                            timestamp = lastTransaction.timeStamp;
-                            transactionValue = lastTransaction.amount;
-                            transactionId = lastTransaction.hash;
-                          }
-                          return WalletModule(
-                            constraints,
-                            ovrCoinName: wallet.currencyName,
-                            ovrCoinSymbol: wallet.currencySymbol,
-                            ovrWalletBalance: wallet.balance.toString(),
-                            ovrLastTransactionID: transactionId,
-                            ovrLastTransactionValue: transactionValue,
-                            ovrTimestamp: timestamp,
-                            ovrTrendLine: trendLine,
-                            ovrCoinImage: WalletUtils.currencySymbolToImage(
-                              wallet.currencySymbol,
-                            ),
-                          );
-                        },
-                      ),
-                    ),
-                  SizedBox(
-                      height: 350,
-                      width: 350,
-                      child: LayoutBuilder(
-                        builder:
-                            (BuildContext context, BoxConstraints constraints) {
-                          return AddWalletBlock(constraints);
-                        },
-                      )),
-                ]);
+                        timestamp = lastTransaction.timeStamp;
+                        transactionValue = lastTransaction.amount;
+                        transactionId = lastTransaction.hash;
+                      }
+                      return WalletModule(
+                        constraints,
+                        ovrCoinName: wallet.currencyName,
+                        ovrCoinSymbol: wallet.currencySymbol,
+                        ovrWalletBalance: wallet.balance.toString(),
+                        ovrLastTransactionID: transactionId,
+                        ovrLastTransactionValue: transactionValue,
+                        ovrTimestamp: timestamp,
+                        ovrTrendLine: trendLine,
+                        ovrCoinImage: WalletUtils.currencySymbolToImage(
+                          wallet.currencySymbol,
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              SizedBox(
+                  height: 350,
+                  width: 350,
+                  child: LayoutBuilder(
+                    builder:
+                        (BuildContext context, BoxConstraints constraints) {
+                      return AddWalletBlock(constraints);
+                    },
+                  )),
+            ]);
           }
           return const Text('No Wallets');
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -89,7 +89,7 @@ class MyApp extends StatelessWidget {
                 backgroundColor: GeniusWalletColors.deepBlueCardColor,
                 useIndicator: true,
                 indicatorColor: GeniusWalletColors.blue500,
-                minWidth: 90,
+                minWidth: 70,
                 labelType: NavigationRailLabelType.none,
                 selectedIconTheme: IconThemeData(color: Colors.white),
                 unselectedIconTheme:

--- a/lib/markets/view/markets_screen.dart
+++ b/lib/markets/view/markets_screen.dart
@@ -5,10 +5,10 @@ import 'package:genius_wallet/app/screens/loading_screen.dart';
 import 'package:genius_wallet/app/utils/breakpoints.dart';
 import 'package:genius_wallet/app/widgets/app_screen_view.dart';
 import 'package:genius_wallet/app/widgets/desktop_container.dart';
+import 'package:genius_wallet/app/widgets/responsive_grid.dart';
 import 'package:genius_wallet/markets/bloc/markets_cubit.dart';
 import 'package:genius_wallet/markets/bloc/markets_state.dart';
 import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
-import 'package:genius_wallet/theme/genius_wallet_consts.dart';
 import 'package:genius_wallet/widgets/components/market_graph.g.dart';
 import 'package:go_router/go_router.dart';
 
@@ -17,7 +17,7 @@ class MarketsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (GeniusBreakpoints.useDesktopLayout(context)) {
+    if (!GeniusBreakpoints.isNativeApp(context)) {
       return BlocProvider(
         create: (context) =>
             MarketsCubit(api: context.read<GeniusApi>())..loadMarkets(),
@@ -48,30 +48,25 @@ class Desktop extends StatelessWidget {
           if (state.marketLoadingStatus == MarketsStatus.loading) {
             return const LoadingScreen();
           }
-          return Wrap(
-              spacing: GeniusWalletConsts.itemSpacing,
-              runSpacing: GeniusWalletConsts.itemSpacing,
-              children: [
-                for (var market in state.markets)
-                  SizedBox(
-                    height: 350,
-                    width: 350,
-                    child: LayoutBuilder(
-                      builder:
-                          (BuildContext context, BoxConstraints constraints) {
-                        //TODO: Get volume, get negative or positive
-                        return MarketGraph(
-                          constraints,
-                          ovrPriceCurrency: market.priceCurrency,
-                          ovrPricePerCoin: market.price,
-                          ovrCoinToFiat:
-                              '${market.symbol}/${market.priceCurrency}',
-                          ovrVolume: null,
-                        );
-                      },
-                    ),
-                  ),
-              ]);
+          return ResponsiveGrid(children: [
+            for (var market in state.markets)
+              SizedBox(
+                height: 350,
+                width: 350,
+                child: LayoutBuilder(
+                  builder: (BuildContext context, BoxConstraints constraints) {
+                    //TODO: Get volume, get negative or positive
+                    return MarketGraph(
+                      constraints,
+                      ovrPriceCurrency: market.priceCurrency,
+                      ovrPricePerCoin: market.price,
+                      ovrCoinToFiat: '${market.symbol}/${market.priceCurrency}',
+                      ovrVolume: null,
+                    );
+                  },
+                ),
+              ),
+          ]);
         }));
   }
 }

--- a/packages/genius_api/README.md
+++ b/packages/genius_api/README.md
@@ -1,39 +1,40 @@
-<!-- 
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# Creating a new model for use in a service to your flutter application.
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+Create a scaffold of your class following this [article](https://pub.dev/packages/freezed) or the example below. <br/>
 
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-library-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/developing-packages). 
--->
-
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
-
-## Features
-
-TODO: List what your package can do. Maybe include images, gifs, or videos.
-
-## Getting started
-
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
-
-## Usage
-
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder. 
-
-```dart
-const like = 'sample';
 ```
 
-## Additional information
+    import 'package:freezed_annotation/freezed_annotation.dart';
 
-TODO: Tell users more about the package: where to find more information, how to 
-contribute to the package, how to file issues, what response they can expect 
-from the package authors, and more.
+    // These 2 parts need to be added after generation
+    part 'events.freezed.dart';
+    part 'events.g.dart';
+
+    @freezed
+    class Events with _$Events {
+    const factory Events(
+        {String? location,
+        String? body,
+        String? weekDay,
+        String? date}) = _Events;
+
+    factory Events.fromJson(Map<String, Object?> json) => _$EventsFromJson(json);
+    }
+
+```
+
+<br/>
+
+Now run the following command within `GeniusWallet/packages/genius_api` - `flutter packages pub run build_runner build`
+
+This will generate:
+
+- `events.freezed.dart`
+- `events.g.dart`
+
+Complete your model by adding these imports to include the generate files
+
+```
+    part 'events.freezed.dart';
+    part 'events.g.dart';
+```

--- a/packages/genius_api/lib/models/events.dart
+++ b/packages/genius_api/lib/models/events.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@freezed
+class Events {
+  final String headline = 'headline placeholder';
+  final String body = 'body placeholdeer';
+  final String date = '1/01/2001';
+
+  Events({headline, body, date});
+}

--- a/packages/genius_api/lib/models/events.dart
+++ b/packages/genius_api/lib/models/events.dart
@@ -1,10 +1,15 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-@freezed
-class Events {
-  final String headline = 'headline placeholder';
-  final String body = 'body placeholdeer';
-  final String date = '1/01/2001';
+part 'events.freezed.dart';
+part 'events.g.dart';
 
-  Events({headline, body, date});
+@freezed
+class Events with _$Events {
+  const factory Events(
+      {String? location,
+      String? body,
+      String? weekDay,
+      String? date}) = _Events;
+
+  factory Events.fromJson(Map<String, Object?> json) => _$EventsFromJson(json);
 }

--- a/packages/genius_api/lib/models/events.freezed.dart
+++ b/packages/genius_api/lib/models/events.freezed.dart
@@ -1,0 +1,200 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'events.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Events _$EventsFromJson(Map<String, dynamic> json) {
+  return _Events.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Events {
+  String? get location => throw _privateConstructorUsedError;
+  String? get body => throw _privateConstructorUsedError;
+  String? get weekDay => throw _privateConstructorUsedError;
+  String? get date => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $EventsCopyWith<Events> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $EventsCopyWith<$Res> {
+  factory $EventsCopyWith(Events value, $Res Function(Events) then) =
+      _$EventsCopyWithImpl<$Res, Events>;
+  @useResult
+  $Res call({String? location, String? body, String? weekDay, String? date});
+}
+
+/// @nodoc
+class _$EventsCopyWithImpl<$Res, $Val extends Events>
+    implements $EventsCopyWith<$Res> {
+  _$EventsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? location = freezed,
+    Object? body = freezed,
+    Object? weekDay = freezed,
+    Object? date = freezed,
+  }) {
+    return _then(_value.copyWith(
+      location: freezed == location
+          ? _value.location
+          : location // ignore: cast_nullable_to_non_nullable
+              as String?,
+      body: freezed == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      weekDay: freezed == weekDay
+          ? _value.weekDay
+          : weekDay // ignore: cast_nullable_to_non_nullable
+              as String?,
+      date: freezed == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$EventsImplCopyWith<$Res> implements $EventsCopyWith<$Res> {
+  factory _$$EventsImplCopyWith(
+          _$EventsImpl value, $Res Function(_$EventsImpl) then) =
+      __$$EventsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String? location, String? body, String? weekDay, String? date});
+}
+
+/// @nodoc
+class __$$EventsImplCopyWithImpl<$Res>
+    extends _$EventsCopyWithImpl<$Res, _$EventsImpl>
+    implements _$$EventsImplCopyWith<$Res> {
+  __$$EventsImplCopyWithImpl(
+      _$EventsImpl _value, $Res Function(_$EventsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? location = freezed,
+    Object? body = freezed,
+    Object? weekDay = freezed,
+    Object? date = freezed,
+  }) {
+    return _then(_$EventsImpl(
+      location: freezed == location
+          ? _value.location
+          : location // ignore: cast_nullable_to_non_nullable
+              as String?,
+      body: freezed == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      weekDay: freezed == weekDay
+          ? _value.weekDay
+          : weekDay // ignore: cast_nullable_to_non_nullable
+              as String?,
+      date: freezed == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$EventsImpl implements _Events {
+  const _$EventsImpl({this.location, this.body, this.weekDay, this.date});
+
+  factory _$EventsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EventsImplFromJson(json);
+
+  @override
+  final String? location;
+  @override
+  final String? body;
+  @override
+  final String? weekDay;
+  @override
+  final String? date;
+
+  @override
+  String toString() {
+    return 'Events(location: $location, body: $body, weekDay: $weekDay, date: $date)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$EventsImpl &&
+            (identical(other.location, location) ||
+                other.location == location) &&
+            (identical(other.body, body) || other.body == body) &&
+            (identical(other.weekDay, weekDay) || other.weekDay == weekDay) &&
+            (identical(other.date, date) || other.date == date));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, location, body, weekDay, date);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$EventsImplCopyWith<_$EventsImpl> get copyWith =>
+      __$$EventsImplCopyWithImpl<_$EventsImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$EventsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Events implements Events {
+  const factory _Events(
+      {final String? location,
+      final String? body,
+      final String? weekDay,
+      final String? date}) = _$EventsImpl;
+
+  factory _Events.fromJson(Map<String, dynamic> json) = _$EventsImpl.fromJson;
+
+  @override
+  String? get location;
+  @override
+  String? get body;
+  @override
+  String? get weekDay;
+  @override
+  String? get date;
+  @override
+  @JsonKey(ignore: true)
+  _$$EventsImplCopyWith<_$EventsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/genius_api/lib/models/events.g.dart
+++ b/packages/genius_api/lib/models/events.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'events.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$EventsImpl _$$EventsImplFromJson(Map<String, dynamic> json) => _$EventsImpl(
+      location: json['location'] as String?,
+      body: json['body'] as String?,
+      weekDay: json['weekDay'] as String?,
+      date: json['date'] as String?,
+    );
+
+Map<String, dynamic> _$$EventsImplToJson(_$EventsImpl instance) =>
+    <String, dynamic>{
+      'location': instance.location,
+      'body': instance.body,
+      'weekDay': instance.weekDay,
+      'date': instance.date,
+    };

--- a/packages/genius_api/lib/models/news.dart
+++ b/packages/genius_api/lib/models/news.dart
@@ -1,9 +1,11 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-class News {
-  final String headline = 'headline placeholder';
-  final String body = 'body placeholdeer';
-  final String date = '1/01/2001';
+part 'news.freezed.dart';
+part 'news.g.dart';
 
-  News({headline, body, date});
+@freezed
+class News with _$News {
+  const factory News({String? headline, String? body, String? date}) = _News;
+
+  factory News.fromJson(Map<String, Object?> json) => _$NewsFromJson(json);
 }

--- a/packages/genius_api/lib/models/news.dart
+++ b/packages/genius_api/lib/models/news.dart
@@ -1,6 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
-@freezed
 class News {
   final String headline = 'headline placeholder';
   final String body = 'body placeholdeer';

--- a/packages/genius_api/lib/models/news.dart
+++ b/packages/genius_api/lib/models/news.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+@freezed
+class News {
+  final String headline = 'headline placeholder';
+  final String body = 'body placeholdeer';
+  final String date = '1/01/2001';
+
+  News({headline, body, date});
+}

--- a/packages/genius_api/lib/models/news.freezed.dart
+++ b/packages/genius_api/lib/models/news.freezed.dart
@@ -1,0 +1,182 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'news.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+News _$NewsFromJson(Map<String, dynamic> json) {
+  return _News.fromJson(json);
+}
+
+/// @nodoc
+mixin _$News {
+  String? get headline => throw _privateConstructorUsedError;
+  String? get body => throw _privateConstructorUsedError;
+  String? get date => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $NewsCopyWith<News> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $NewsCopyWith<$Res> {
+  factory $NewsCopyWith(News value, $Res Function(News) then) =
+      _$NewsCopyWithImpl<$Res, News>;
+  @useResult
+  $Res call({String? headline, String? body, String? date});
+}
+
+/// @nodoc
+class _$NewsCopyWithImpl<$Res, $Val extends News>
+    implements $NewsCopyWith<$Res> {
+  _$NewsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? headline = freezed,
+    Object? body = freezed,
+    Object? date = freezed,
+  }) {
+    return _then(_value.copyWith(
+      headline: freezed == headline
+          ? _value.headline
+          : headline // ignore: cast_nullable_to_non_nullable
+              as String?,
+      body: freezed == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      date: freezed == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$NewsImplCopyWith<$Res> implements $NewsCopyWith<$Res> {
+  factory _$$NewsImplCopyWith(
+          _$NewsImpl value, $Res Function(_$NewsImpl) then) =
+      __$$NewsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String? headline, String? body, String? date});
+}
+
+/// @nodoc
+class __$$NewsImplCopyWithImpl<$Res>
+    extends _$NewsCopyWithImpl<$Res, _$NewsImpl>
+    implements _$$NewsImplCopyWith<$Res> {
+  __$$NewsImplCopyWithImpl(_$NewsImpl _value, $Res Function(_$NewsImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? headline = freezed,
+    Object? body = freezed,
+    Object? date = freezed,
+  }) {
+    return _then(_$NewsImpl(
+      headline: freezed == headline
+          ? _value.headline
+          : headline // ignore: cast_nullable_to_non_nullable
+              as String?,
+      body: freezed == body
+          ? _value.body
+          : body // ignore: cast_nullable_to_non_nullable
+              as String?,
+      date: freezed == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$NewsImpl implements _News {
+  const _$NewsImpl({this.headline, this.body, this.date});
+
+  factory _$NewsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$NewsImplFromJson(json);
+
+  @override
+  final String? headline;
+  @override
+  final String? body;
+  @override
+  final String? date;
+
+  @override
+  String toString() {
+    return 'News(headline: $headline, body: $body, date: $date)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NewsImpl &&
+            (identical(other.headline, headline) ||
+                other.headline == headline) &&
+            (identical(other.body, body) || other.body == body) &&
+            (identical(other.date, date) || other.date == date));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, headline, body, date);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$NewsImplCopyWith<_$NewsImpl> get copyWith =>
+      __$$NewsImplCopyWithImpl<_$NewsImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$NewsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _News implements News {
+  const factory _News(
+      {final String? headline,
+      final String? body,
+      final String? date}) = _$NewsImpl;
+
+  factory _News.fromJson(Map<String, dynamic> json) = _$NewsImpl.fromJson;
+
+  @override
+  String? get headline;
+  @override
+  String? get body;
+  @override
+  String? get date;
+  @override
+  @JsonKey(ignore: true)
+  _$$NewsImplCopyWith<_$NewsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/genius_api/lib/models/news.g.dart
+++ b/packages/genius_api/lib/models/news.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'news.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$NewsImpl _$$NewsImplFromJson(Map<String, dynamic> json) => _$NewsImpl(
+      headline: json['headline'] as String?,
+      body: json['body'] as String?,
+      date: json['date'] as String?,
+    );
+
+Map<String, dynamic> _$$NewsImplToJson(_$NewsImpl instance) =>
+    <String, dynamic>{
+      'headline': instance.headline,
+      'body': instance.body,
+      'date': instance.date,
+    };

--- a/packages/genius_api/lib/src/genius_api.dart
+++ b/packages/genius_api/lib/src/genius_api.dart
@@ -266,9 +266,31 @@ class GeniusApi {
   Future<List<Events>> getEvents() async {
     await Future.delayed(Duration(seconds: 2));
     return [
-      Events(headline: 'headline1', body: 'body1', date: '01/01/01'),
-      Events(headline: 'headline2', body: 'body2', date: '01/02/01'),
-      Events(headline: 'headline3', body: 'body3', date: '01/03/01')
+      Events(
+          body: 'Blockchain in Energy Conference',
+          date: 'October 5',
+          location: 'Rome',
+          weekDay: "Monday"),
+      Events(
+          body: 'Blockchain in Energy Conference 2',
+          date: 'October 8',
+          location: 'Rome',
+          weekDay: "Thursday"),
+      Events(
+          body: 'Blockchain in Energy Conference 3',
+          date: 'October 9',
+          location: 'Rome',
+          weekDay: "Friday"),
+      Events(
+          body: 'Blockchain in Energy Conference 4',
+          date: 'October 22',
+          location: 'Rome',
+          weekDay: "Monday"),
+      Events(
+          body: 'Blockchain in Energy Conference 5',
+          date: 'October 23',
+          location: 'Rome',
+          weekDay: "Tuesday"),
     ];
   }
 }

--- a/packages/genius_api/lib/src/genius_api.dart
+++ b/packages/genius_api/lib/src/genius_api.dart
@@ -4,6 +4,8 @@ import 'dart:ffi' as ffi;
 
 import 'package:genius_api/ffi_bridge_prebuilt.dart';
 import 'package:genius_api/models/currency.dart';
+import 'package:genius_api/models/events.dart';
+import 'package:genius_api/models/news.dart';
 import 'package:genius_api/models/transaction.dart';
 import 'package:genius_api/models/user.dart';
 import 'package:genius_api/models/wallet.dart';
@@ -229,6 +231,44 @@ class GeniusApi {
         priceCurrency: 'USD',
         priceDate: DateTime.now().toIso8601String(),
       ),
+    ];
+  }
+
+  Future<List<Currency>> get() async {
+    await Future.delayed(Duration(seconds: 2));
+    return [
+      Currency(
+        symbol: 'BTC',
+        name: 'Bitcoin',
+        price: '17000',
+        priceCurrency: 'USD',
+        priceDate: DateTime.now().toIso8601String(),
+      ),
+      Currency(
+        symbol: 'ETH',
+        name: 'Ethereum',
+        price: '1300',
+        priceCurrency: 'USD',
+        priceDate: DateTime.now().toIso8601String(),
+      ),
+    ];
+  }
+
+  Future<List<News>> getNews() async {
+    await Future.delayed(Duration(seconds: 2));
+    return [
+      News(headline: 'headline1', body: 'body1', date: '01/01/01'),
+      News(headline: 'headline2', body: 'body2', date: '01/02/01'),
+      News(headline: 'headline3', body: 'body3', date: '01/03/01')
+    ];
+  }
+
+  Future<List<Events>> getEvents() async {
+    await Future.delayed(Duration(seconds: 2));
+    return [
+      Events(headline: 'headline1', body: 'body1', date: '01/01/01'),
+      Events(headline: 'headline2', body: 'body2', date: '01/02/01'),
+      Events(headline: 'headline3', body: 'body3', date: '01/03/01')
     ];
   }
 }


### PR DESCRIPTION
This pr adds the generate services for news / events screens. Cubits / states and wiring. News screen still a work in progress.
Fully built events screen
Responsive grid component added and updated the markets, events and wallets screens to be more responsive
Fixes transaction screens overflow issues
Fixes navigation rail ordering, icons, icon sizing and overflowing issue
Improvements to the desktop search header
Documentation on generating service classes with "freezed" package

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/d65eaa93-6ab2-498c-a8f3-9d54f84bad10">

<img width="781" alt="image" src="https://github.com/user-attachments/assets/0af656fe-2ae8-4305-a500-d7ad7deb1a98">

