### PR TITLE
Create Trust Wallet, Save Wallet into Local Storage

### DIFF
--- a/lib/app/utils/wallet_utils.dart
+++ b/lib/app/utils/wallet_utils.dart
@@ -1,6 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:genius_api/genius_api.dart';
-import 'package:genius_api/models/wallet.dart';
+
+final symbolImageMap = {
+  'ETH': Image.asset(
+    'assets/images/ethereum_icon.png',
+    package: 'genius_wallet',
+  ),
+  'BTC': Image.asset(
+    'assets/images/bitcoin_icon.png',
+    package: 'genius_wallet',
+  ),
+  null: const SizedBox()
+};
 
 class WalletUtils {
   /// Iterates [wallets] and returns the number of transactions as an [int].
@@ -34,20 +45,7 @@ class WalletUtils {
   /// ```
   /// currencySymbolToImage('ETH') -> Image.asset('path/to/ETH.png')
   /// ```
-  static Widget currencySymbolToImage(String symbol) {
-    switch (symbol) {
-      case 'ETH':
-        return Image.asset(
-          'assets/images/ethereum_icon.png',
-          package: 'genius_wallet',
-        );
-      case 'BTC':
-        return Image.asset(
-          'assets/images/bitcoin_icon.png',
-          package: 'genius_wallet',
-        );
-      default:
-        return const SizedBox();
-    }
+  static Widget? currencySymbolToImage(String symbol) {
+    return symbolImageMap[symbol.trim()];
   }
 }

--- a/lib/dashboard/home/widgets/horizontal_wallets_scrollview.dart
+++ b/lib/dashboard/home/widgets/horizontal_wallets_scrollview.dart
@@ -28,14 +28,13 @@ class HorizontalWalletsScrollview extends StatelessWidget {
                     onPressed: () {
                       context.push('/wallets/${currentWallet.address}');
                     },
-                    child: WalletPreview(
-                      constraints,
-                      ovrWalletBalance: currentWallet.balance.toString(),
-                      ovrCoinType: currentWallet.currencyName,
-                      ovrCoinSymbol: currentWallet.currencySymbol,
-                      ovrCoinIcon: WalletUtils.currencySymbolToImage(
-                          currentWallet.currencySymbol),
-                    ),
+                    child: WalletPreview(constraints,
+                        ovrWalletBalance: currentWallet.balance.toString(),
+                        ovrCoinType: currentWallet.currencyName,
+                        ovrCoinSymbol: currentWallet.currencySymbol,
+                        ovrCoinIcon: WalletUtils.currencySymbolToImage(
+                            currentWallet.currencySymbol),
+                        walletName: currentWallet.walletName),
                   );
                 }),
               );

--- a/lib/dashboard/wallets/view/wallets_screen.dart
+++ b/lib/dashboard/wallets/view/wallets_screen.dart
@@ -64,6 +64,7 @@ class Desktop extends StatelessWidget {
                       }
                       return WalletModule(
                         constraints,
+                        walletAddress: wallet.address,
                         ovrCoinName: wallet.currencyName,
                         ovrCoinSymbol: wallet.currencySymbol,
                         ovrWalletBalance: wallet.balance.toString(),
@@ -193,6 +194,7 @@ class Mobile extends StatelessWidget {
                                 }
                                 return WalletModule(
                                   constraints,
+                                  walletAddress: currentWallet.address,
                                   ovrCoinName: currentWallet.currencyName,
                                   ovrCoinSymbol: currentWallet.currencySymbol,
                                   ovrWalletBalance:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,7 +39,7 @@ class MyApp extends StatelessWidget {
           ),
         ],
         child: MaterialApp.router(
-          title: 'Flutter Demo',
+          title: 'Gnus AI',
           theme: ThemeData(
             textButtonTheme: const TextButtonThemeData(
                 style: ButtonStyle(

--- a/lib/onboarding/new_wallet/bloc/new_wallet_bloc.dart
+++ b/lib/onboarding/new_wallet/bloc/new_wallet_bloc.dart
@@ -17,7 +17,6 @@ class NewWalletBloc extends Bloc<NewWalletEvent, NewWalletState> {
       required this.api,
       required this.wallet})
       : super(initialState) {
-    api.saveWallet(null);
     on<LoadRecoveryPhrase>(onLoadRecoveryPhrase);
 
     on<RecoveryPhraseContinue>(_onRecoveryPhraseContinue);

--- a/lib/onboarding/new_wallet/bloc/new_wallet_bloc.dart
+++ b/lib/onboarding/new_wallet/bloc/new_wallet_bloc.dart
@@ -17,6 +17,7 @@ class NewWalletBloc extends Bloc<NewWalletEvent, NewWalletState> {
       required this.api,
       required this.wallet})
       : super(initialState) {
+    api.saveWallet(null);
     on<LoadRecoveryPhrase>(onLoadRecoveryPhrase);
 
     on<RecoveryPhraseContinue>(_onRecoveryPhraseContinue);

--- a/lib/onboarding/new_wallet/bloc/new_wallet_event.dart
+++ b/lib/onboarding/new_wallet/bloc/new_wallet_event.dart
@@ -20,7 +20,7 @@ class RecoveryVerificationContinue extends NewWalletEvent {}
 class ToggleCheckbox extends NewWalletEvent {}
 
 class AddWallet extends NewWalletEvent {
-  final Wallet wallet;
+  final HDWallet wallet;
 
   AddWallet({required this.wallet});
 }

--- a/lib/onboarding/new_wallet/view/verify_recovery_phrase_screen.dart
+++ b/lib/onboarding/new_wallet/view/verify_recovery_phrase_screen.dart
@@ -27,21 +27,10 @@ class VerifyRecoveryPhraseScreen extends StatelessWidget {
     return BlocListener<NewWalletBloc, NewWalletState>(
       listener: (context, state) {
         if (state.verificationStatus == VerificationStatus.passed) {
-          /// TODO: probably want to create the wallet step-by-step once the API is available
-          final random = Random();
-          final uuid = random.nextInt(99999999);
-          // context.read<NewWalletBloc>().add(
-          //       AddWallet(
-          //         wallet: Wallet(
-          //           walletName: 'dummy_wallet',
-          //           currencySymbol: 'ETH',
-          //           currencyName: 'Ethereum',
-          //           address: uuid.toString(),
-          //           balance: 0,
-          //           transactions: [],
-          //         ),
-          //       ),
-          //     );
+          final newWalletBloc = context.read<NewWalletBloc>();
+          newWalletBloc.add(
+            AddWallet(wallet: newWalletBloc.wallet),
+          );
 
           context.flow<NewWalletState>().complete();
         } else if (state.verificationStatus == VerificationStatus.failed) {

--- a/lib/onboarding/new_wallet/view/verify_recovery_phrase_screen.dart
+++ b/lib/onboarding/new_wallet/view/verify_recovery_phrase_screen.dart
@@ -30,18 +30,18 @@ class VerifyRecoveryPhraseScreen extends StatelessWidget {
           /// TODO: probably want to create the wallet step-by-step once the API is available
           final random = Random();
           final uuid = random.nextInt(99999999);
-          context.read<NewWalletBloc>().add(
-                AddWallet(
-                  wallet: Wallet(
-                    walletName: 'dummy_wallet',
-                    currencySymbol: 'ETH',
-                    currencyName: 'Ethereum',
-                    address: uuid.toString(),
-                    balance: 0,
-                    transactions: [],
-                  ),
-                ),
-              );
+          // context.read<NewWalletBloc>().add(
+          //       AddWallet(
+          //         wallet: Wallet(
+          //           walletName: 'dummy_wallet',
+          //           currencySymbol: 'ETH',
+          //           currencyName: 'Ethereum',
+          //           address: uuid.toString(),
+          //           balance: 0,
+          //           transactions: [],
+          //         ),
+          //       ),
+          //     );
 
           context.flow<NewWalletState>().complete();
         } else if (state.verificationStatus == VerificationStatus.failed) {

--- a/lib/onboarding/widgets/recovery_words.dart
+++ b/lib/onboarding/widgets/recovery_words.dart
@@ -41,11 +41,12 @@ class RecoveryWordButton extends StatefulWidget {
   final bool isIncludeIndex;
   final int index;
   final String value;
-  const RecoveryWordButton(
-      {super.key,
-      required this.index,
-      required this.value,
-      required this.isIncludeIndex});
+  const RecoveryWordButton({
+    super.key,
+    required this.index,
+    required this.value,
+    required this.isIncludeIndex,
+  });
 
   @override
   State<StatefulWidget> createState() {
@@ -62,8 +63,19 @@ class _RecoveryWordButton extends State<RecoveryWordButton> {
     });
   }
 
+  void enable() {
+    setState(() {
+      isEnabled = true;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
+    if (context.read<NewWalletBloc>().state.verificationStatus ==
+        VerificationStatus.failed) {
+      enable();
+    }
+
     return MaterialButton(
       onPressed: isEnabled
           ? () {

--- a/lib/theme/genius_wallet_colors.g.dart
+++ b/lib/theme/genius_wallet_colors.g.dart
@@ -66,4 +66,6 @@ class GeniusWalletColors {
   static const Color btnCopyBorder = Color.fromRGBO(255, 255, 255, 0.30);
 
   static const Color borderGrey = Color.fromRGBO(255, 255, 255, 0.30);
+
+  static const Color currencyBackground = Color(0xff0050b7);
 }

--- a/lib/widgets/components/wallet_module.g.dart
+++ b/lib/widgets/components/wallet_module.g.dart
@@ -18,18 +18,19 @@ class WalletModule extends StatefulWidget {
   final String? ovrTimestamp;
   final Widget? ovrTrendLine;
   final String? ovrCoinSymbol;
-  const WalletModule(
-    this.constraints, {
-    Key? key,
-    this.ovrCoinImage,
-    this.ovrWalletBalance,
-    this.ovrCoinName,
-    this.ovrLastTransactionID,
-    this.ovrLastTransactionValue,
-    this.ovrTimestamp,
-    this.ovrTrendLine,
-    this.ovrCoinSymbol,
-  }) : super(key: key);
+  final String? walletAddress;
+  const WalletModule(this.constraints,
+      {Key? key,
+      this.ovrCoinImage,
+      this.ovrWalletBalance,
+      this.ovrCoinName,
+      this.ovrLastTransactionID,
+      this.ovrLastTransactionValue,
+      this.ovrTimestamp,
+      this.ovrTrendLine,
+      this.ovrCoinSymbol,
+      this.walletAddress})
+      : super(key: key);
   @override
   _WalletModule createState() => _WalletModule();
 }
@@ -128,8 +129,8 @@ class _WalletModule extends State<WalletModule> {
           Positioned(
             left: 20.0,
             right: 20.0,
-            bottom: 22.0,
-            height: 72.0,
+            bottom: 0,
+            height: 100.0,
             child: Container(
                 decoration: BoxDecoration(),
                 child: Stack(children: [
@@ -185,6 +186,23 @@ class _WalletModule extends State<WalletModule> {
                         width: widget.constraints.maxWidth * 0.7877813504823151,
                         child: AutoSizeText(
                           widget.ovrLastTransactionID ??
+                              '1PRj85hu9RXPZTzxtko9stfs6nRo1vyrQB',
+                          style: TextStyle(
+                            fontFamily: 'Roboto',
+                            fontSize: 12.0,
+                            fontWeight: FontWeight.w400,
+                            letterSpacing: 0.30000001192092896,
+                            color: Colors.white,
+                          ),
+                          textAlign: TextAlign.center,
+                        )),
+                  ),
+                  Positioned(
+                    top: 85.0,
+                    child: Container(
+                        width: widget.constraints.maxWidth * 0.7877813504823151,
+                        child: AutoSizeText(
+                          widget.walletAddress ??
                               '1PRj85hu9RXPZTzxtko9stfs6nRo1vyrQB',
                           style: TextStyle(
                             fontFamily: 'Roboto',

--- a/lib/widgets/components/wallet_preview.g.dart
+++ b/lib/widgets/components/wallet_preview.g.dart
@@ -15,14 +15,15 @@ class WalletPreview extends StatefulWidget {
   final String? ovrWalletBalance;
   final Widget? ovrCoinIcon;
   final String? ovrCoinSymbol;
-  const WalletPreview(
-    this.constraints, {
-    Key? key,
-    this.ovrCoinType,
-    this.ovrWalletBalance,
-    this.ovrCoinIcon,
-    this.ovrCoinSymbol,
-  }) : super(key: key);
+  final String? walletName;
+  const WalletPreview(this.constraints,
+      {Key? key,
+      this.ovrCoinType,
+      this.ovrWalletBalance,
+      this.ovrCoinIcon,
+      this.ovrCoinSymbol,
+      this.walletName = ""})
+      : super(key: key);
   @override
   _WalletPreview createState() => _WalletPreview();
 }
@@ -61,12 +62,12 @@ class _WalletPreview extends State<WalletPreview> {
                 width: 73.0,
                 bottom: 13.0,
                 height: 19.0,
-                child: Container(
+                child: SizedBox(
                     height: 19.0,
                     width: 73.0,
                     child: AutoSizeText(
-                      widget.ovrCoinType ?? 'Bitcoin',
-                      style: TextStyle(
+                      widget.walletName ?? "",
+                      style: const TextStyle(
                         fontFamily: 'Roboto',
                         fontSize: 16.0,
                         fontWeight: FontWeight.w300,
@@ -81,12 +82,12 @@ class _WalletPreview extends State<WalletPreview> {
                 width: 102.0,
                 bottom: 12.0,
                 height: 28.0,
-                child: Container(
+                child: SizedBox(
                     height: 28.0,
                     width: 102.0,
                     child: AutoSizeText(
                       widget.ovrWalletBalance ?? '0.221746',
-                      style: TextStyle(
+                      style: const TextStyle(
                         fontFamily: 'Roboto',
                         fontSize: 24.0,
                         fontWeight: FontWeight.w300,
@@ -101,47 +102,29 @@ class _WalletPreview extends State<WalletPreview> {
                 width: 35.0,
                 top: 9.0,
                 height: 35.0,
-                child: Container(
-                    decoration: BoxDecoration(),
+                child: SizedBox(
                     child: Stack(children: [
-                      Positioned(
-                        right: 0,
-                        width: 35.0,
-                        top: 0,
-                        height: 35.0,
-                        child: Container(
-                          height: 35.0,
-                          width: 35.0,
-                          decoration: const BoxDecoration(
-                            color: Color(0xff0050b7),
-                            borderRadius:
-                                BorderRadius.all(Radius.circular(2.0)),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Color(0x2dffffff),
-                                spreadRadius: 0.0,
-                                blurRadius: 0.0,
-                                offset: Offset(0.0, 2.0),
-                              ),
-                            ],
-                          ),
-                        ),
+                  Positioned(
+                    right: 0,
+                    width: 35.0,
+                    top: 0,
+                    height: 35.0,
+                    child: Container(
+                      height: 35.0,
+                      width: 35.0,
+                      decoration: const BoxDecoration(
+                        color: GeniusWalletColors.currencyBackground,
+                        borderRadius: BorderRadius.all(Radius.circular(2.0)),
                       ),
-                      Positioned(
-                        left: 8.922,
-                        width: 16.484,
-                        top: 7.656,
-                        height: 21.82,
-                        child: widget.ovrCoinIcon ??
-                            Image.asset(
-                              'assets/images/coinicon.png',
-                              package: 'genius_wallet',
-                              height: 21.820068359375,
-                              width: 16.484375,
-                              fit: BoxFit.none,
-                            ),
-                      ),
-                    ])),
+                    ),
+                  ),
+                  Positioned(
+                      left: 8.922,
+                      width: 16.484,
+                      top: 7.656,
+                      height: 21.82,
+                      child: widget.ovrCoinIcon ?? const SizedBox()),
+                ])),
               ),
               Positioned(
                 left: 12.0,

--- a/lib/widgets/components/wallet_toggle.g.dart
+++ b/lib/widgets/components/wallet_toggle.g.dart
@@ -1,12 +1,6 @@
-// *********************************************************************************
-// PARABEAC-GENERATED CODE. DO NOT MODIFY.
-//
-// FOR MORE INFORMATION ON HOW TO USE PARABEAC, PLEASE VISIT docs.parabeac.com
-// *********************************************************************************
-
 import 'package:flutter/material.dart';
+import 'package:genius_wallet/theme/genius_wallet_colors.g.dart';
 import 'package:genius_wallet/widgets/components/custom/coin_toggle_custom.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 
 class WalletToggle extends StatefulWidget {
@@ -56,7 +50,7 @@ class _WalletToggle extends State<WalletToggle> {
                   width: 35.0,
                   padding: const EdgeInsets.all(5),
                   decoration: const BoxDecoration(
-                    color: Color(0xfff2921b),
+                    color: GeniusWalletColors.currencyBackground,
                     borderRadius: BorderRadius.all(Radius.circular(2.0)),
                   ),
                   child: widget.ovrShape ??

--- a/packages/genius_api/lib/models/wallet_stored.dart
+++ b/packages/genius_api/lib/models/wallet_stored.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'wallet_stored.freezed.dart';
+part 'wallet_stored.g.dart';
+
+@freezed
+class WalletStored with _$WalletStored {
+  const factory WalletStored({
+    required String walletName,
+    required String currencySymbol,
+    required String currencyName,
+    required String mnemonic,
+    required String address,
+  }) = _WalletStored;
+
+  factory WalletStored.fromJson(Map<String, Object?> json) =>
+      _$WalletStoredFromJson(json);
+}

--- a/packages/genius_api/lib/models/wallet_stored.freezed.dart
+++ b/packages/genius_api/lib/models/wallet_stored.freezed.dart
@@ -1,0 +1,240 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'wallet_stored.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+WalletStored _$WalletStoredFromJson(Map<String, dynamic> json) {
+  return _WalletStored.fromJson(json);
+}
+
+/// @nodoc
+mixin _$WalletStored {
+  String get walletName => throw _privateConstructorUsedError;
+  String get currencySymbol => throw _privateConstructorUsedError;
+  String get currencyName => throw _privateConstructorUsedError;
+  String get mnemonic => throw _privateConstructorUsedError;
+  String get address => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $WalletStoredCopyWith<WalletStored> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WalletStoredCopyWith<$Res> {
+  factory $WalletStoredCopyWith(
+          WalletStored value, $Res Function(WalletStored) then) =
+      _$WalletStoredCopyWithImpl<$Res, WalletStored>;
+  @useResult
+  $Res call(
+      {String walletName,
+      String currencySymbol,
+      String currencyName,
+      String mnemonic,
+      String address});
+}
+
+/// @nodoc
+class _$WalletStoredCopyWithImpl<$Res, $Val extends WalletStored>
+    implements $WalletStoredCopyWith<$Res> {
+  _$WalletStoredCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? walletName = null,
+    Object? currencySymbol = null,
+    Object? currencyName = null,
+    Object? mnemonic = null,
+    Object? address = null,
+  }) {
+    return _then(_value.copyWith(
+      walletName: null == walletName
+          ? _value.walletName
+          : walletName // ignore: cast_nullable_to_non_nullable
+              as String,
+      currencySymbol: null == currencySymbol
+          ? _value.currencySymbol
+          : currencySymbol // ignore: cast_nullable_to_non_nullable
+              as String,
+      currencyName: null == currencyName
+          ? _value.currencyName
+          : currencyName // ignore: cast_nullable_to_non_nullable
+              as String,
+      mnemonic: null == mnemonic
+          ? _value.mnemonic
+          : mnemonic // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$WalletStoredImplCopyWith<$Res>
+    implements $WalletStoredCopyWith<$Res> {
+  factory _$$WalletStoredImplCopyWith(
+          _$WalletStoredImpl value, $Res Function(_$WalletStoredImpl) then) =
+      __$$WalletStoredImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String walletName,
+      String currencySymbol,
+      String currencyName,
+      String mnemonic,
+      String address});
+}
+
+/// @nodoc
+class __$$WalletStoredImplCopyWithImpl<$Res>
+    extends _$WalletStoredCopyWithImpl<$Res, _$WalletStoredImpl>
+    implements _$$WalletStoredImplCopyWith<$Res> {
+  __$$WalletStoredImplCopyWithImpl(
+      _$WalletStoredImpl _value, $Res Function(_$WalletStoredImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? walletName = null,
+    Object? currencySymbol = null,
+    Object? currencyName = null,
+    Object? mnemonic = null,
+    Object? address = null,
+  }) {
+    return _then(_$WalletStoredImpl(
+      walletName: null == walletName
+          ? _value.walletName
+          : walletName // ignore: cast_nullable_to_non_nullable
+              as String,
+      currencySymbol: null == currencySymbol
+          ? _value.currencySymbol
+          : currencySymbol // ignore: cast_nullable_to_non_nullable
+              as String,
+      currencyName: null == currencyName
+          ? _value.currencyName
+          : currencyName // ignore: cast_nullable_to_non_nullable
+              as String,
+      mnemonic: null == mnemonic
+          ? _value.mnemonic
+          : mnemonic // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$WalletStoredImpl implements _WalletStored {
+  const _$WalletStoredImpl(
+      {required this.walletName,
+      required this.currencySymbol,
+      required this.currencyName,
+      required this.mnemonic,
+      required this.address});
+
+  factory _$WalletStoredImpl.fromJson(Map<String, dynamic> json) =>
+      _$$WalletStoredImplFromJson(json);
+
+  @override
+  final String walletName;
+  @override
+  final String currencySymbol;
+  @override
+  final String currencyName;
+  @override
+  final String mnemonic;
+  @override
+  final String address;
+
+  @override
+  String toString() {
+    return 'WalletStored(walletName: $walletName, currencySymbol: $currencySymbol, currencyName: $currencyName, mnemonic: $mnemonic, address: $address)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$WalletStoredImpl &&
+            (identical(other.walletName, walletName) ||
+                other.walletName == walletName) &&
+            (identical(other.currencySymbol, currencySymbol) ||
+                other.currencySymbol == currencySymbol) &&
+            (identical(other.currencyName, currencyName) ||
+                other.currencyName == currencyName) &&
+            (identical(other.mnemonic, mnemonic) ||
+                other.mnemonic == mnemonic) &&
+            (identical(other.address, address) || other.address == address));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, walletName, currencySymbol, currencyName, mnemonic, address);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$WalletStoredImplCopyWith<_$WalletStoredImpl> get copyWith =>
+      __$$WalletStoredImplCopyWithImpl<_$WalletStoredImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$WalletStoredImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _WalletStored implements WalletStored {
+  const factory _WalletStored(
+      {required final String walletName,
+      required final String currencySymbol,
+      required final String currencyName,
+      required final String mnemonic,
+      required final String address}) = _$WalletStoredImpl;
+
+  factory _WalletStored.fromJson(Map<String, dynamic> json) =
+      _$WalletStoredImpl.fromJson;
+
+  @override
+  String get walletName;
+  @override
+  String get currencySymbol;
+  @override
+  String get currencyName;
+  @override
+  String get mnemonic;
+  @override
+  String get address;
+  @override
+  @JsonKey(ignore: true)
+  _$$WalletStoredImplCopyWith<_$WalletStoredImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/genius_api/lib/models/wallet_stored.g.dart
+++ b/packages/genius_api/lib/models/wallet_stored.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'wallet_stored.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$WalletStoredImpl _$$WalletStoredImplFromJson(Map<String, dynamic> json) =>
+    _$WalletStoredImpl(
+      walletName: json['walletName'] as String,
+      currencySymbol: json['currencySymbol'] as String,
+      currencyName: json['currencyName'] as String,
+      mnemonic: json['mnemonic'] as String,
+      address: json['address'] as String,
+    );
+
+Map<String, dynamic> _$$WalletStoredImplToJson(_$WalletStoredImpl instance) =>
+    <String, dynamic>{
+      'walletName': instance.walletName,
+      'currencySymbol': instance.currencySymbol,
+      'currencyName': instance.currencyName,
+      'mnemonic': instance.mnemonic,
+      'address': instance.address,
+    };

--- a/packages/genius_api/lib/tw/any_address.dart
+++ b/packages/genius_api/lib/tw/any_address.dart
@@ -1,0 +1,38 @@
+import 'dart:ffi';
+import 'dart:typed_data';
+
+import 'package:genius_api/ffi_bridge_prebuilt.dart';
+import 'package:genius_api/tw/any_address_impl.dart';
+import 'package:genius_api/tw/public_key.dart';
+
+/// Create any type of wallet address for a multi HD Wallet
+class AnyAddress {
+  static FFIBridgePrebuilt ffiBridgePrebuilt = FFIBridgePrebuilt();
+  late Pointer<Void> pointer;
+
+  AnyAddress.createWithString(String address, int coinType) {
+    pointer = AnyAddressImpl.createWithString(address, coinType);
+  }
+
+  AnyAddress.createWithPublicKey(PublicKey publicKey, int coinType) {
+    pointer =
+        AnyAddressImpl.createWithPublicKey(publicKey.nativehandle, coinType);
+  }
+
+  static bool isValid(String address, int coinType) {
+    return AnyAddressImpl.isValid(address, coinType);
+  }
+
+  Uint8List data() {
+    return AnyAddressImpl.data(pointer);
+  }
+
+  String description() {
+    return AnyAddressImpl.description(pointer);
+  }
+
+  void delete() {
+    AnyAddressImpl.delete(pointer);
+    pointer = nullptr;
+  }
+}

--- a/packages/genius_api/lib/tw/any_address_impl.dart
+++ b/packages/genius_api/lib/tw/any_address_impl.dart
@@ -1,0 +1,51 @@
+import 'dart:ffi';
+import 'dart:typed_data';
+
+import 'package:genius_api/ffi_bridge_prebuilt.dart';
+import 'package:genius_api/tw/string_util.dart';
+
+class AnyAddressImpl {
+  static FFIBridgePrebuilt ffiBridgePrebuilt = FFIBridgePrebuilt();
+  static bool isValid(String address, int coinType) {
+    final twAddress = StringUtil.toTWString(address);
+    final result = ffiBridgePrebuilt.wallet_lib
+        .TWAnyAddressIsValid(twAddress.cast(), coinType);
+    StringUtil.delete(twAddress);
+    return result;
+  }
+
+  static Pointer<Void> createWithString(String address, int coinType) {
+    final twAddress = StringUtil.toTWString(address);
+    final result = ffiBridgePrebuilt.wallet_lib
+        .TWAnyAddressCreateWithString(twAddress.cast(), coinType);
+    StringUtil.delete(twAddress);
+    return result.cast();
+  }
+
+  static Pointer<Void> createWithPublicKey(
+      Pointer<Void> publicKey, int coinType) {
+    final result = ffiBridgePrebuilt.wallet_lib
+        .TWAnyAddressCreateWithPublicKey(publicKey.cast(), coinType);
+    return result.cast();
+  }
+
+  static Uint8List data(Pointer<Void> anyAddress) {
+    final addressData =
+        ffiBridgePrebuilt.wallet_lib.TWAnyAddressData(anyAddress.cast());
+
+    final result = ffiBridgePrebuilt.wallet_lib
+        .TWDataBytes(addressData)
+        .asTypedList(ffiBridgePrebuilt.wallet_lib.TWDataSize(addressData));
+    return result;
+  }
+
+  static String description(Pointer<Void> anyAddress) {
+    final twString =
+        ffiBridgePrebuilt.wallet_lib.TWAnyAddressDescription(anyAddress.cast());
+    return StringUtil.toDartString(twString.cast());
+  }
+
+  static void delete(Pointer<Void> address) {
+    ffiBridgePrebuilt.wallet_lib.TWAnyAddressDelete(address.cast());
+  }
+}

--- a/packages/genius_api/lib/tw/hd_wallet.dart
+++ b/packages/genius_api/lib/tw/hd_wallet.dart
@@ -19,7 +19,7 @@ class HDWallet {
     }
   }
 
-  HDWallet.createWithMnemonic(String mnemonic, {String passphrase = ""}) {
+  HDWallet.createWithMnemonic(String mnemonic, {String passphrase = "gnusai"}) {
     nativehandle =
         HDWalletImpl.createWithMnemonic(mnemonic, passphrase: passphrase);
     if (nativehandle.hashCode == 0) {
@@ -27,7 +27,7 @@ class HDWallet {
     }
   }
 
-  HDWallet.createWithData(Uint8List bytes, {String passphrase = ""}) {
+  HDWallet.createWithData(Uint8List bytes, {String passphrase = "gnusai"}) {
     nativehandle =
         HDWalletImpl.createWithEntropy(bytes, passphrase: passphrase);
     if (nativehandle.hashCode == 0) {
@@ -55,7 +55,7 @@ class HDWallet {
     return PrivateKey.pointer(pointer);
   }
 
-  PrivateKey getMaterKey(int curve) {
+  PrivateKey getMasterKey(int curve) {
     final pointer = HDWalletImpl.getMasterKey(nativehandle, curve);
     return PrivateKey.pointer(pointer);
   }

--- a/packages/genius_api/lib/tw/hd_wallet.dart
+++ b/packages/genius_api/lib/tw/hd_wallet.dart
@@ -11,7 +11,7 @@ class HDWallet {
     nativehandle = pointer;
   }
 
-  HDWallet({int strength = 128, String passphrase = "gnusai"}) {
+  HDWallet({int strength = 128, String passphrase = ""}) {
     nativehandle =
         HDWalletImpl.create(strength: strength, passphrase: passphrase);
     if (nativehandle.hashCode == 0) {
@@ -19,7 +19,7 @@ class HDWallet {
     }
   }
 
-  HDWallet.createWithMnemonic(String mnemonic, {String passphrase = "gnusai"}) {
+  HDWallet.createWithMnemonic(String mnemonic, {String passphrase = ""}) {
     nativehandle =
         HDWalletImpl.createWithMnemonic(mnemonic, passphrase: passphrase);
     if (nativehandle.hashCode == 0) {
@@ -27,7 +27,7 @@ class HDWallet {
     }
   }
 
-  HDWallet.createWithData(Uint8List bytes, {String passphrase = "gnusai"}) {
+  HDWallet.createWithData(Uint8List bytes, {String passphrase = ""}) {
     nativehandle =
         HDWalletImpl.createWithEntropy(bytes, passphrase: passphrase);
     if (nativehandle.hashCode == 0) {

--- a/packages/genius_api/lib/tw/private_key.dart
+++ b/packages/genius_api/lib/tw/private_key.dart
@@ -5,7 +5,7 @@ import 'package:genius_api/extensions/extensions.dart';
 import 'package:genius_api/ffi/genius_api_ffi.dart' as ffi;
 import 'package:genius_api/ffi_bridge_prebuilt.dart';
 import 'package:genius_api/tw/private_key_impl.dart';
-import 'package:genius_api/tw/tw_public_key.dart';
+import 'package:genius_api/tw/public_key.dart';
 
 class PrivateKey {
   static FFIBridgePrebuilt ffiBridgePrebuilt = FFIBridgePrebuilt();
@@ -52,7 +52,7 @@ class PrivateKey {
         .asTypedList(ffiBridgePrebuilt.wallet_lib.TWDataSize(data));
   }
 
-  TWPublicKey getTWPublicKey(int curve, [bool compressed = false]) {
+  PublicKey getTWPublicKey(int curve, [bool compressed = false]) {
     switch (curve) {
       case ffi.TWCurve.TWCurveSECP256k1:
         return getTWPublicKeySecp256k1(compressed);
@@ -71,46 +71,46 @@ class PrivateKey {
     }
   }
 
-  TWPublicKey getTWPublicKeySecp256k1(bool compressed) {
+  PublicKey getTWPublicKeySecp256k1(bool compressed) {
     final data = ffiBridgePrebuilt.wallet_lib
         .TWPrivateKeyGetPublicKeySecp256k1(nativehandle.cast(), compressed);
-    return TWPublicKey(data.cast());
+    return PublicKey(data.cast());
   }
 
-  TWPublicKey getTWPublicKeyNist256p1() {
+  PublicKey getTWPublicKeyNist256p1() {
     final data = ffiBridgePrebuilt.wallet_lib
         .TWPrivateKeyGetPublicKeyNist256p1(nativehandle.cast());
-    return TWPublicKey(data.cast());
+    return PublicKey(data.cast());
   }
 
-  TWPublicKey getTWPublicKeyNistEd25519() {
+  PublicKey getTWPublicKeyNistEd25519() {
     final data = ffiBridgePrebuilt.wallet_lib
         .TWPrivateKeyGetPublicKeyEd25519(nativehandle.cast());
-    return TWPublicKey(data.cast());
+    return PublicKey(data.cast());
   }
 
-  TWPublicKey getTWPublicKeyNistEd25519Blake2b() {
+  PublicKey getTWPublicKeyNistEd25519Blake2b() {
     final data = ffiBridgePrebuilt.wallet_lib
         .TWPrivateKeyGetPublicKeyEd25519Blake2b(nativehandle.cast());
-    return TWPublicKey(data.cast());
+    return PublicKey(data.cast());
   }
 
-  TWPublicKey getTWPublicKeyEd25519Cardano() {
+  PublicKey getTWPublicKeyEd25519Cardano() {
     final data = ffiBridgePrebuilt.wallet_lib
         .TWPrivateKeyGetPublicKeyEd25519Cardano(nativehandle.cast());
-    return TWPublicKey(data.cast());
+    return PublicKey(data.cast());
   }
 
-  TWPublicKey getTWPublicKeyCurve25519() {
+  PublicKey getTWPublicKeyCurve25519() {
     final data = ffiBridgePrebuilt.wallet_lib
         .TWPrivateKeyGetPublicKeyCurve25519(nativehandle.cast());
-    return TWPublicKey(data.cast());
+    return PublicKey(data.cast());
   }
 
-  TWPublicKey getShareKey(TWPublicKey twPublicKey, int curve) {
+  PublicKey getShareKey(PublicKey twPublicKey, int curve) {
     final data =
         PrivateKeyImpl.getShareKey(nativehandle, twPublicKey.pointer, curve);
-    return TWPublicKey(data);
+    return PublicKey(data);
   }
 
   Uint8List sign(Uint8List digest, int curve) {

--- a/packages/genius_api/lib/tw/public_key.dart
+++ b/packages/genius_api/lib/tw/public_key.dart
@@ -23,8 +23,8 @@ class PublicKey {
         .cast();
   }
 
-  static bool isValid(Uint8List data, int publivKeyType) {
-    return PublicKeyImpl.isValid(data, publivKeyType);
+  static bool isValid(Uint8List data, int publicKeyType) {
+    return PublicKeyImpl.isValid(data, publicKeyType);
   }
 
   Uint8List data() {

--- a/packages/genius_api/lib/tw/stored_key.dart
+++ b/packages/genius_api/lib/tw/stored_key.dart
@@ -56,8 +56,8 @@ class StoredKey {
   }
 
   static StoredKey? importJson(String json) {
-    final _j = Uint8List.fromList(json.codeUnits);
-    final pointer = StoredKeyImpl.importJson(_j);
+    final codeUnits = Uint8List.fromList(json.codeUnits);
+    final pointer = StoredKeyImpl.importJson(codeUnits);
     if (pointer == null) {
       return null;
     }
@@ -102,9 +102,9 @@ class StoredKey {
   }
 
   void addAccount(String address, int coin, String derivationPath,
-      String publicKey, String extetndedPublicKey) {
+      String publicKey, String extendedPublicKey) {
     StoredKeyImpl.addAccount(nativehandle, address, coin, derivationPath,
-        publicKey, extetndedPublicKey);
+        publicKey, extendedPublicKey);
   }
 
   bool store(String path) {

--- a/packages/local_secure_storage/lib/src/local_secure_storage_base.dart
+++ b/packages/local_secure_storage/lib/src/local_secure_storage_base.dart
@@ -84,17 +84,16 @@ class LocalWalletStorage extends SecureStorage {
 
     final walletJsonStr = await _secureStorage.read(key: _walletCollectionKey);
 
-    if (walletJsonStr == null) {
-      return;
-    }
-
     walletsController.add(currentWallets);
 
-    final walletsMap =
-        List<Map<String, dynamic>>.from(jsonDecode(walletJsonStr));
+    final walletsMap = walletJsonStr != null
+        ? List<Map<String, dynamic>>.from(jsonDecode(walletJsonStr))
+        : null;
 
-    List<WalletStored> storedWallets =
-        walletsMap.map(WalletStored.fromJson).toList();
+    List<WalletStored> storedWallets = walletsMap != null
+        ? walletsMap.map(WalletStored.fromJson).toList()
+        : [];
+
     storedWallets.add(wallet);
 
     await _secureStorage.write(

--- a/packages/secure_storage/lib/src/secure_storage.dart
+++ b/packages/secure_storage/lib/src/secure_storage.dart
@@ -6,7 +6,6 @@ abstract class SecureStorage {
   /// [BehaviorSubject] used to stream the [List] of {}
   final walletsController = BehaviorSubject<List<Wallet>>.seeded([]);
 
-  // TODO: do not return the mnemonic here for the wallets, need to filter it out..
   Stream<List<Wallet>> getWallets() => walletsController.asBroadcastStream();
 
   Future<void> saveWallet(WalletStored wallet);

--- a/packages/secure_storage/lib/src/secure_storage.dart
+++ b/packages/secure_storage/lib/src/secure_storage.dart
@@ -1,13 +1,15 @@
 import 'package:genius_api/genius_api.dart';
+import 'package:genius_api/models/wallet_stored.dart';
 import 'package:rxdart/rxdart.dart';
 
 abstract class SecureStorage {
   /// [BehaviorSubject] used to stream the [List] of {}
   final walletsController = BehaviorSubject<List<Wallet>>.seeded([]);
 
+  // TODO: do not return the mnemonic here for the wallets, need to filter it out..
   Stream<List<Wallet>> getWallets() => walletsController.asBroadcastStream();
 
-  Future<void> saveWallet(Wallet wallet);
+  Future<void> saveWallet(WalletStored wallet);
 
   Future<void> deleteWallet(String walletAddress);
 


### PR DESCRIPTION
This iteration only allows for creating an eth address in the multi-coin wallet.

- Save wallet data into local storage, including mnemonic
- Does not retrieve mnemonic when accessing wallets for the UI
- Handle multiple duplicate wallets
- Map wallets coin type to an image for UI
- Reset recovery words if validation fails
- Add wallet delete to UI wallet info screen