### PR TITLE
chore: adopt GSD planning workflow (.planning/ scaffolding)

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,81 @@
+# GeniusWallet
+
+## What This Is
+
+GeniusWallet is a Flutter/Dart self-custody crypto wallet targeting Windows, mobile, and web. It manages EVM wallets and integrates the native GeniusSDK (SGNUS) over Dart FFI, alongside fiat on-ramp (Banxa), cross-chain swaps (Squid Router), and dApp connectivity (Reown/WalletConnect). It is a mature, in-production codebase; GSD is being adopted onto it to structure ongoing work.
+
+## Core Value
+
+Users can safely custody their keys and reliably perform core wallet actions (create/import wallet, view balances, send/receive, swap, buy) — correctness and key safety come before everything else.
+
+## Requirements
+
+### Validated
+
+<!-- Inferred from the codebase map (.planning/codebase/) — existing, relied-upon capabilities. -->
+
+- ✓ Wallet onboarding: create new wallet, import existing, recovery-phrase backup/verify, PIN/keystore — existing (`lib/onboarding`)
+- ✓ Dashboard: balances, holdings, transactions, markets, news — existing (`lib/dashboard`, `lib/wallets`)
+- ✓ Fiat on-ramp via Banxa buy flow + order history/details — existing (`lib/banxa`, `lib/screens`)
+- ✓ Cross-chain swaps via Squid Router — existing (`lib/squid_router`)
+- ✓ dApp connectivity via Reown/WalletConnect — existing (`lib/reown`)
+- ✓ SGNUS / GeniusSDK integration over FFI (init status, processing, connection stream) — existing (`packages/genius_api`)
+- ✓ Token info + market data (CoinGecko), charts — existing (`lib/tokens`, `lib/tokeninfo`, `lib/chart`)
+- ✓ go_router navigation shell with responsive overlay + bottom nav — existing (`lib/navigation`, `lib/components/overlay`)
+- ✓ Brand design system / theme tokens — existing (`lib/theme`)
+
+### Active
+
+<!-- Current near-term scope. Kept thin per "minimal GSD infra" milestone. -->
+
+- [ ] Adopt GSD workflow for the project (this branch: `chore/adopt-gsd`)
+- [ ] Complete & harden the UI-redesign forward-port onto `develop` (branch `ui-redesign-3.514-develop`): remaining low-priority develop drops, `import_wallet_screen.dart` re-skin, visual/UAT pass on the nav shell, then merge to `develop`
+
+### Out of Scope
+
+- Broad new-feature milestones (staking, new chains, etc.) — deferred until GSD infra is in place and the redesign forward-port lands
+- Re-architecting develop's structure — the forward-port deliberately keeps develop's structure/logic and applies the redesign skin on top
+- Big-bang merge of `origin/ui-redesign-3.514` into develop — rejected after analysis (115 conflicts, structural collisions); the manual forward-port is the chosen path
+
+## Context
+
+- **Brownfield adoption.** GSD is being layered onto an existing app. See `.planning/codebase/` for architecture, stack, conventions, testing, integrations, and concerns.
+- **UI-redesign forward-port in flight.** A designer's redesign (`origin/ui-redesign-3.514`, based on an April-2026 develop snapshot) is being re-applied onto current `develop` via a clean rewrite on `ui-redesign-3.514-develop` (~87% done, 0 analyze errors). A fidelity audit (2026-07-15) confirmed it faithful: 8 minor develop-logic drops, 0 high-severity; the 3 medium drops (`network_page` SDK-init polling, `sgnus_connection_widget` init-progress polling, `image_utils` null-guard) are already ported and pushed.
+- **Branching for this adoption.** `.planning/` scaffolding is isolated on `chore/adopt-gsd` (off `develop`) as its own PR, to keep the redesign PR clean.
+
+## Constraints
+
+- **Tech stack**: Flutter pinned to **3.41.9** / Dart ~3.11 — the native deps and pubspec require it; do not bump casually.
+- **Native build**: Windows build is CMake-driven and pulls prebuilt GeniusSDK/thirdparty binaries from GitHub releases (no checksum pinning). Requires VS Build Tools ≥14.40 + ATL, Developer Mode on.
+- **Analysis gap**: `analysis_options.yaml` excludes `lib/**/*.g.dart` — the compiler, not `flutter analyze`, is the real gate for generated widgets.
+- **Testing**: no working test harness — `flutter test` does not compile on the forward-port branch. Verification leans on `flutter analyze` + build + manual UAT.
+- **Security**: crypto wallet — seed/key handling, FFI boundary, and WalletConnect sessions are sensitive. See `.planning/codebase/CONCERNS.md`.
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Manual forward-port over merging `ui-redesign-3.514` | 7-agent analysis: merge yields 115 conflicts incl. structural modify/delete collisions; both paths need the same ~106 semantic calls, but the manual branch already made them and compiles | ✓ Good |
+| Isolate GSD `.planning/` on `chore/adopt-gsd` (own PR, off develop) | Keeps the redesign PR focused; `.planning/` is project infra for the whole team | — Pending |
+| Interactive mode (not YOLO) | GSD config is committed to the shared repo, so a conservative, approval-gated mode is safer for team-shared automation | — Pending |
+| Minimal first milestone (adopt infra only) | Establish a usable `.planning/` now; defer broad milestone planning until the forward-port lands | — Pending |
+
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition** (via `/gsd-transition`):
+1. Requirements invalidated? → Move to Out of Scope with reason
+2. Requirements validated? → Move to Validated with phase reference
+3. New requirements emerged? → Add to Active
+4. Decisions to log? → Add to Key Decisions
+5. "What This Is" still accurate? → Update if drifted
+
+**After each milestone** (via `/gsd-complete-milestone`):
+1. Full review of all sections
+2. Core Value check — still the right priority?
+3. Audit Out of Scope — reasons still valid?
+4. Update Context with current state
+
+---
+*Last updated: 2026-07-15 after initialization*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,54 @@
+# Requirements: GeniusWallet
+
+**Defined:** 2026-07-15
+**Core Value:** Users can safely custody their keys and reliably perform core wallet actions.
+
+## v1 Requirements
+
+Scope of the current (minimal) milestone: adopt GSD and complete/harden the UI-redesign forward-port onto `develop`.
+
+### Tooling (GSD)
+
+- [ ] **GSD-01**: `.planning/` GSD infrastructure established (PROJECT, config, codebase map, roadmap, state) and committed on `chore/adopt-gsd`
+
+### Redesign Forward-Port (RFP)
+
+- [ ] **RFP-01**: Remaining low-priority develop-logic drops on `ui-redesign-3.514-develop` are reviewed and reconciled (port or consciously drop): `dashboard_screen` pull-to-refresh, `crypto_live_chart` window/timestamps, `reown_connect_button` init guard, `crypto_news_screen` retry/refresh, `coins_screen` poll interval
+- [ ] **RFP-02**: `lib/onboarding/existing_wallet/view/import_wallet_screen.dart` re-skinned to the redesign
+- [ ] **RFP-03**: Nav shell and key flows (onboarding, dashboard, swap, Banxa) pass a visual/UAT review — the nav shell has never been eyeballed
+- [ ] **RFP-04**: Forward-port branch merged into `develop` with `flutter analyze` = 0 errors and a successful Windows build
+
+## v2 Requirements
+
+Deferred to future milestones (post-forward-port).
+
+### App
+
+- **APP-01**: Broader feature roadmap (new chains, staking, etc.) — scoped in a later milestone
+- **APP-02**: Establish a working automated test harness (`flutter test` currently does not compile)
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Big-bang merge of `origin/ui-redesign-3.514` | Rejected after analysis — 115 conflicts, structural collisions |
+| Re-architecting develop's structure | Forward-port keeps develop's structure/logic, applies skin on top |
+| New feature milestones | Deferred until forward-port lands |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| GSD-01 | Phase 1 | Pending |
+| RFP-01 | Phase 2 | Pending |
+| RFP-02 | Phase 2 | Pending |
+| RFP-03 | Phase 3 | Pending |
+| RFP-04 | Phase 4 | Pending |
+
+**Coverage:**
+- v1 requirements: 5 total
+- Mapped to phases: 5
+- Unmapped: 0
+
+---
+*Last updated: 2026-07-15 after initialization*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,81 @@
+# Roadmap: GeniusWallet
+
+## Overview
+
+This is a brownfield GSD adoption. The current milestone is intentionally minimal: stand up GSD's `.planning/` infrastructure, then complete and harden the in-flight UI-redesign forward-port (`ui-redesign-3.514-develop`) and land it on `develop`. Broader app roadmapping is deferred to a later milestone once the forward-port ships.
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+
+- [ ] **Phase 1: Adopt GSD** - Establish and commit `.planning/` infrastructure
+- [ ] **Phase 2: Forward-port fidelity** - Reconcile remaining develop-logic drops + re-skin import wallet screen
+- [ ] **Phase 3: Visual & UAT hardening** - Eyeball the nav shell and key flows, fix regressions
+- [ ] **Phase 4: Merge to develop** - Land the forward-port on develop, analyze-clean + building
+
+## Phase Details
+
+### Phase 1: Adopt GSD
+**Goal**: A committed, usable GSD setup on `chore/adopt-gsd`
+**Depends on**: Nothing (first phase)
+**Requirements**: GSD-01
+**Success Criteria** (what must be TRUE):
+  1. `.planning/` contains PROJECT.md, config.json, codebase map, REQUIREMENTS.md, ROADMAP.md, STATE.md
+  2. The setup is committed and ready to open as its own PR into `develop`
+**Plans**: TBD
+
+Plans:
+- [ ] 01-01: Finalize and commit `.planning/` scaffolding
+
+### Phase 2: Forward-port fidelity
+**Goal**: The forward-port carries every develop behavior worth keeping, plus the last redesign skin gap
+**Depends on**: Phase 1
+**Requirements**: RFP-01, RFP-02
+**Success Criteria** (what must be TRUE):
+  1. Each of the 5 low-priority develop drops is either ported or consciously dropped with a note
+  2. `import_wallet_screen.dart` is re-skinned to the redesign
+  3. `flutter analyze` stays at 0 errors
+**Plans**: TBD
+
+Plans:
+- [ ] 02-01: Reconcile the 5 low-priority develop-logic drops
+- [ ] 02-02: Re-skin `import_wallet_screen.dart`
+
+### Phase 3: Visual & UAT hardening
+**Goal**: The redesign is confirmed correct at runtime, not just analyze-clean
+**Depends on**: Phase 2
+**Requirements**: RFP-03
+**Success Criteria** (what must be TRUE):
+  1. The nav shell is walked visually (it has never been eyeballed)
+  2. Onboarding, dashboard, swap, and Banxa flows are exercised and pass
+  3. Any regressions found are fixed
+**Plans**: TBD
+
+Plans:
+- [ ] 03-01: Build + walk the app, log and fix visual/UAT regressions
+
+### Phase 4: Merge to develop
+**Goal**: The forward-port lands on `develop`
+**Depends on**: Phase 3
+**Requirements**: RFP-04
+**Success Criteria** (what must be TRUE):
+  1. `flutter analyze` = 0 errors and a Windows release build succeeds
+  2. Branch merged into `develop` (via PR)
+**Plans**: TBD
+
+Plans:
+- [ ] 04-01: Final verification and merge
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 1 → 2 → 3 → 4
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Adopt GSD | 0/1 | Not started | - |
+| 2. Forward-port fidelity | 0/2 | Not started | - |
+| 3. Visual & UAT hardening | 0/1 | Not started | - |
+| 4. Merge to develop | 0/1 | Not started | - |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,59 @@
+---
+gsd_state_version: '1.0'
+status: planning
+progress:
+  total_phases: 4
+  completed_phases: 0
+  total_plans: 5
+  completed_plans: 0
+  percent: 0
+---
+
+# Project State
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-07-15)
+
+**Core value:** Users can safely custody their keys and reliably perform core wallet actions.
+**Current focus:** Phase 1 — Adopt GSD
+
+## Current Position
+
+Phase: 1 of 4 (Adopt GSD)
+Plan: 0 of 1 in current phase
+Status: Ready to plan
+Last activity: 2026-07-15 — Initialized GSD (brownfield): codebase map, PROJECT.md, config, requirements, roadmap
+
+Progress: [░░░░░░░░░░] 0%
+
+## Accumulated Context
+
+### Decisions
+
+Full log in PROJECT.md Key Decisions. Recent:
+
+- Manual forward-port chosen over merging `ui-redesign-3.514` (115-conflict merge, structural collisions)
+- GSD `.planning/` isolated on `chore/adopt-gsd` (own PR) to keep the redesign PR clean
+- Interactive mode (config is committed to the shared repo)
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+- No working automated test harness (`flutter test` does not compile) — verification leans on `flutter analyze` + build + manual UAT
+- Nav shell has never been visually walked (Phase 3 addresses this)
+
+## Deferred Items
+
+| Category | Item | Status | Deferred At |
+|----------|------|--------|-------------|
+| *(none)* | | | |
+
+## Session Continuity
+
+Last session: 2026-07-15
+Stopped at: GSD initialization complete on `chore/adopt-gsd`; ready to plan Phase 1
+Resume file: None

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,363 @@
+<!-- refreshed: 2026-07-15 -->
+# Architecture
+
+**Analysis Date:** 2026-07-15
+
+## System Overview
+
+```text
+┌──────────────────────────────────────────────────────────────────────────┐
+│                        Flutter/Material UI Layer                         │
+│   Views & Widgets (lib/*/view, lib/screens)                              │
+│   • Dashboard, Transactions, Swap, Markets, News, Settings, Onboarding   │
+└────────────────┬─────────────────────────────────┬──────────────────────┘
+                 │                                 │
+                 ▼                                 ▼
+┌──────────────────────────────┐    ┌──────────────────────────────┐
+│  Navigation & Shell Layout   │    │  Theme & Design System       │
+│  lib/navigation/router.dart  │    │  lib/theme/                  │
+│  GoRouter + ShellRoute       │    │  (colors, gradients, consts) │
+│  lib/components/overlay/     │    │                              │
+│  responsive_overlay.dart     │    │  Responsive Breakpoints      │
+└─────────────┬────────────────┘    │  lib/utils/breakpoints.dart  │
+              │                      └──────────────────────────────┘
+              │
+              ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│                    State Management Layer (BLoC/Cubit)                   │
+│                                                                          │
+│  Main: AppBloc (lib/bloc/app_bloc.dart)                                  │
+│    • SDK initialization, wallet loading, account management              │
+│    • SGNUS connection streaming, transaction streaming                   │
+│    • Events: InitializeSDK, LoadWallets, FetchAccount,                  │
+│      StartSGNUSTransactionsStream, SelectSDKAccount, etc.               │
+│                                                                          │
+│  Feature Cubits:                                                        │
+│    • WalletDetailsCubit (lib/wallets/cubit/) - wallet & coin selection  │
+│    • TransactionsCubit (lib/dashboard/transactions/cubit/)              │
+│    • OrdersCubit (lib/banxa/banxa_order/) - Banxa orders                │
+│    • SubmitJobCubit (lib/submit_job/cubit/) - job submissions           │
+│    • PollingCubit (lib/banxa/banxa_order/) - order polling              │
+│    • GnusCubit (lib/dashboard/gnus/cubit/) - GNUS token data            │
+│                                                                          │
+│  Providers (ChangeNotifier + Provider):                                 │
+│    • NetworkProvider (lib/providers/network_provider.dart)              │
+│    • NetworkTokensProvider (lib/providers/network_tokens_provider.dart) │
+└────────────┬──────────────────────────────────────────────────────────┘
+             │
+             ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│                      Data & Services Layer                               │
+│                                                                          │
+│  Core API Facade:                                                        │
+│    • GeniusApi (packages/genius_api/lib/src/genius_api.dart)            │
+│      - Wraps native GeniusSDK via FFI bindings                          │
+│      - Manages wallet streams, SGNUS transactions, account operations   │
+│      - Web3 transaction broadcasting via web3dart                       │
+│                                                                          │
+│  External Services:                                                     │
+│    • BanxaApiService (lib/banxa/banxa_api_services.dart)               │
+│    • CoinGeckoApi (lib/services/coin_gecko/coin_gecko_api.dart)        │
+│    • CoinTelegraphApi (lib/services/coin_telegraph/)                   │
+│    • Web3 (packages/genius_api/lib/web3/web3.dart)                     │
+│    • SecureStorage (packages/local_secure_storage/)                    │
+│                                                                          │
+│  Data Controllers (RxDart BehaviorSubject streams):                     │
+│    • SGNUSConnectionController                                          │
+│    • SGNUSTransactionsController                                        │
+│    • _walletsController (in GeniusApi)                                  │
+└────────────┬──────────────────────────────────────────────────────────┘
+             │
+             ▼
+┌──────────────────────────────────────────────────────────────────────────┐
+│                  Local Persistence & Platform Layer                      │
+│                                                                          │
+│  Hive NoSQL Database (lib/hive/):                                       │
+│    • HiveModels: CoinGeckoMarketData, CoinGeckoCoin,                   │
+│      HistoricalPriceEntry, NewsArticle                                  │
+│    • Boxes: marketDataBox, coinsBox, priceHistoryBox, newsBox          │
+│    • TransactionStorageService for persistent transaction caching       │
+│                                                                          │
+│  SecureStorage (packages/local_secure_storage/):                        │
+│    • Wallet mnemonic/private key encryption (platform-specific)        │
+│    • iOS: Keychain; Android: KeyStore; Windows: DPAPI                  │
+│                                                                          │
+│  FFI Bindings (packages/genius_api/lib/ffi/):                           │
+│    • GeniusApiFFI - native GeniusSDK C interface                        │
+│    • TrustWalletApiFFI - Trust Wallet core (HD wallets, signing)       │
+│    • FFIBridgePrebuilt - prebuilt binary coordination                   │
+│                                                                          │
+│  Platform-Specific:                                                     │
+│    • WindowManager (desktop navigation/lifecycle)                       │
+│    • WebViewFlutter/WebViewWindows (in-app web browsing)               │
+│    • PathProvider (app documents directory)                             │
+│    • AppLinks (deep linking)                                            │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+## Component Responsibilities
+
+| Component | Responsibility | File |
+|-----------|----------------|------|
+| **AppBloc** | App-wide state (SDK init, wallets, accounts, SGNUS stream) | `lib/bloc/app_bloc.dart` |
+| **Router** | Navigation with GoRouter, redirect guards, route matching | `lib/navigation/router.dart` |
+| **Overlay** | Responsive shell (mobile/desktop), bottom nav, app bar | `lib/components/overlay/responsive_overlay.dart` |
+| **GeniusApi** | Wallet creation, signing, FFI bridge, secure storage | `packages/genius_api/lib/src/genius_api.dart` |
+| **WalletDetailsCubit** | Wallet/network/coin selection, balance updates | `lib/wallets/cubit/wallet_details_cubit.dart` |
+| **TransactionsCubit** | Transaction history loading & caching | `lib/dashboard/transactions/cubit/transactions_cubit.dart` |
+| **OrdersCubit** | Banxa order history & filtering | `lib/banxa/banxa_order/banxa_order_cubit.dart` |
+| **Theme** | Design tokens, colors, gradients, responsive breakpoints | `lib/theme/` |
+| **Components** | Shared widgets (buttons, QR, toast, overlay, coins list) | `lib/components/` |
+| **Hive** | Local DB schemas, boxes, migration logic | `lib/hive/` |
+| **Providers** | Network and token metadata loaders | `lib/providers/` |
+| **Services** | External API integrations (CoinGecko, Banxa, Web3) | `lib/services/` |
+
+## Pattern Overview
+
+**Overall:** Domain-driven, feature-based architecture with explicit layering.
+
+**Key Characteristics:**
+- **Separation of Concerns:** UI layer (views/widgets) → State (BLoC/Cubit) → Data (services/API)
+- **Reactive Streams:** RxDart BehaviorSubjects for wallet/transaction state; stream subscriptions in AppBloc
+- **Provider Pattern:** ChangeNotifier for app-wide providers (network, tokens); RepositoryProvider for GeniusApi
+- **Feature Isolation:** Each domain (onboarding, dashboard, banxa, squid_router, etc.) has its own cubit/bloc and view directory
+- **Responsive Design:** LayoutBuilder + MediaQuery for mobile/tablet/desktop adaptation
+- **Platform Abstraction:** FFI for native SDK, platform-specific secure storage, conditional web view imports
+
+## Layers
+
+**UI Layer:**
+- Purpose: Render user-facing screens and interactive components
+- Location: `lib/*/view/`, `lib/screens/`, `lib/components/`
+- Contains: Widgets, screens, reusable components (buttons, cards, dialogs)
+- Depends on: BLoC/Cubit (state), GeniusApi (injected via context)
+- Used by: Go Router navigation, Shell layout
+
+**Navigation Layer:**
+- Purpose: Route management, deep linking, guard logic
+- Location: `lib/navigation/router.dart`, `lib/onboarding/routes/`, `lib/components/overlay/`
+- Contains: GoRouter definition, redirect logic, route guards, responsive shell
+- Depends on: AppBloc (redirect checks), BLoC/Cubit (route builders)
+- Used by: MyApp MaterialApp.router
+
+**State Management Layer:**
+- Purpose: Encapsulate business logic, emit new states, manage side effects
+- Location: `lib/bloc/`, `lib/**/cubit/`, `lib/providers/`
+- Contains: BLoC (multi-event, state) and Cubit (single method, state) classes
+- Depends on: GeniusApi, services, secure storage
+- Used by: UI (BlocBuilder/BlocListener), router redirects
+
+**Data Layer:**
+- Purpose: Abstract external APIs, provide unified data interface
+- Location: `packages/genius_api/`, `lib/services/`
+- Contains: GeniusApi facade, Banxa/CoinGecko clients, Web3 broadcaster, transaction cache
+- Depends on: FFI bindings, SecureStorage, HTTP clients (http, web3dart)
+- Used by: BLoC/Cubit (for data fetching)
+
+**Persistence Layer:**
+- Purpose: Local caching and sensitive data encryption
+- Location: `lib/hive/`, `packages/local_secure_storage/`
+- Contains: Hive boxes (marketData, coins, news, price history), secure storage (wallets, keys)
+- Depends on: Hive plugin, platform-specific keychain/keystore APIs
+- Used by: Services (cache), GeniusApi (load/save wallets)
+
+## Data Flow
+
+### Primary Request Path: User Views Dashboard
+
+1. **Router Redirect** (`lib/navigation/router.dart:49-69`)
+   - GoRouter.redirect checks AppBloc state (sdkStatus, subscribeToWalletStatus, accountStatus)
+   - If initial, emits InitializeSDK → LoadWallets → FetchAccount → StartSGNUSTransactionsStream
+
+2. **AppBloc Initialization** (`lib/bloc/app_bloc.dart:57-125`)
+   - InitializeSDK calls GeniusApi.initSDK() (FFI)
+   - LoadWallets loads wallets from secure storage via GeniusApi.getWallets()
+   - Starts SGNUS connection listener
+   - Emits AppState with wallets, selectedSDKAccount, sdkAccounts
+   - Calls WalletDetailsCubit.loadInitial() and TransactionsCubit.loadInitial()
+
+3. **Dashboard View Render** (`lib/dashboard/home/view/dashboard_screen.dart:47-75`)
+   - BlocBuilder<AppBloc> checks subscribeToWalletStatus == loaded
+   - Calls WalletDetailsCubit.getCoins() in initState
+   - Renders ResponsiveDashboardView (desktop) or OneColumnDashBoardView (mobile)
+
+4. **Coin & Balance Update** (`lib/wallets/cubit/wallet_details_cubit.dart:79-95`)
+   - getCoins() fetches coin balances for selected wallet+network via GeniusApi
+   - CoinGeckoApi (if enabled) enriches with market prices
+   - WalletDetailsCubit emits new state with coins list
+   - UI re-renders coin cards with live prices
+
+### Secondary Flow: Transaction Processing & SGNUS Connection
+
+1. **SGNUS Listener** (`lib/bloc/app_bloc.dart:165+`)
+   - AppBloc starts StreamSubscription to _sgnusConnectionSubscription
+   - GeniusApi broadcasts SGNUSConnection (connected, processing, disconnected)
+   - On connection, AppBloc polls processing status every 1s (ProcessingStatusTicked)
+
+2. **Transaction Stream** (`lib/bloc/app_bloc.dart:43-58`)
+   - AppBloc.StartSGNUSTransactionsStream subscribes to GeniusApi.getSGNUSTransactionsController()
+   - New transactions flow to TransactionsCubit
+   - TransactionsCubit stores in Hive cache (TransactionStorageService)
+   - UI (TransactionsScreen) displays via StreamBuilder
+
+3. **Order Flow (Banxa)** (`lib/navigation/router.dart:84-95`, `lib/banxa/banxa_order/create_order_cubit.dart`)
+   - User navigates to /createOrder
+   - MakeOrderCubit calls BanxaApiService.createOrder()
+   - Order ID returned, user navigated to /checkout (WebView)
+   - PollingCubit polls order status until complete
+   - OrderDetailsPage displays final status
+
+**State Management:**
+- **AppBloc** holds wallet list, accounts, processing status (updated every 1s)
+- **WalletDetailsCubit** holds selected wallet/network/coin, balance, token list
+- **Providers** (NetworkProvider, NetworkTokensProvider) load once at startup, notifyListeners on changes
+- **Hive** caches market data, coins, news articles, price history (survives app restart)
+- **Streams** (BehaviorSubject) for wallets, SGNUS transactions (emit latest value to new subscribers)
+
+## Key Abstractions
+
+**Wallet Abstraction:**
+- Purpose: Unified interface over multi-chain wallets (EVM, Bitcoin, etc.)
+- Examples: `lib/wallets/cubit/wallet_details_cubit.dart`, `packages/genius_api/models/wallet.dart`
+- Pattern: Wallet model holds address, balance, type (external/import), associated network
+
+**Transaction Abstraction:**
+- Purpose: Cache and stream transactions from SGNUS and chain RPC
+- Examples: `lib/dashboard/transactions/cubit/transactions_cubit.dart`, `SGNUSTransactionsController`
+- Pattern: TransactionsCubit loads paginated history, Hive caches, streams new via controller
+
+**Coin/Token Abstraction:**
+- Purpose: Represent blockchain assets with metadata and market prices
+- Examples: `packages/genius_api/models/coin.dart`, `lib/hive/models/coin_gecko_coin.dart`
+- Pattern: Coin model from GeniusApi, enriched with CoinGecko market data in Hive
+
+**Order Abstraction (Banxa):**
+- Purpose: Unified order lifecycle (create, poll, complete, callback)
+- Examples: `lib/banxa/banxa_model.dart`, `lib/banxa/banxa_order/banxa_order_cubit.dart`
+- Pattern: OrdersCubit holds cached orders, PollingCubit handles status polling
+
+## Entry Points
+
+**App Entry:**
+- Location: `lib/main.dart:66`
+- Triggers: App launch (platform: Android/iOS/Windows/macOS/Web)
+- Responsibilities: 
+  - Initialize Sentry error tracking
+  - Initialize Hive local DB
+  - Load SecureStorage (wallets)
+  - Create GeniusApi instance
+  - Load NetworkProvider and NetworkTokensProvider
+  - Fetch all CoinGecko coins
+  - Load stored wallets
+  - Initialize WindowManager (desktop)
+  - Set up MultiProvider and MultiBlocProvider
+  - Run MyApp with MaterialApp.router(geniusWalletRouter)
+
+**Navigation Entry:**
+- Location: `lib/navigation/router.dart:46`
+- Triggers: Routing on app startup and user navigation
+- Responsibilities: 
+  - Redirect guards (check AppBloc state before allowing route access)
+  - Route matching (/dashboard, /swap, /buy, /onboarding, etc.)
+  - ShellRoute layout (ResponsiveOverlay for mobile/desktop)
+  - Deep link handling (Banxa callback, wallet connect, etc.)
+
+**Onboarding Entry:**
+- Location: `lib/onboarding/routes/wallet_routes.dart:22+`
+- Triggers: First app launch (no wallets detected) or user creates new wallet
+- Responsibilities: 
+  - Route user through wallet creation or import flow
+  - Collect mnemonic/private key via NewWalletBloc or ExistingWalletBloc
+  - Create wallet via GeniusApi.createWallet() or importWallet()
+  - Persist in SecureStorage
+
+**Feature Entries (via ShellRoute):**
+- Dashboard (`/dashboard`) → DashboardScreen → coins, balance, transactions
+- Transactions (`/transactions`) → TransactionsScreen → tx history with filters
+- Swap (`/swap`) → SwapScreen → Squid Router integration
+- Markets (`/markets`) → MarketsScreen → CoinGecko prices
+- Buy (`/buy` or `/createOrder`) → Banxa integration screens
+
+## Architectural Constraints
+
+- **Threading:** Single-threaded event loop (Flutter); FFI calls (GeniusSDK, TrustWallet) may block briefly
+- **Global state:** GeniusApi (singleton via RepositoryProvider), AppBloc (single instance), Hive boxes (singletons)
+- **Circular imports:** Minimal (separate part files in bloc for events/state); packages/genius_api is acyclic
+- **Platform differences:** 
+  - Windows/macOS desktop: WindowManager for lifecycle, WebViewWindows for browsing
+  - Linux: No web view support (conditional route in router)
+  - iOS: Uses native Keychain for secure storage
+  - Android: Uses native KeyStore for secure storage
+  - Web: device_preview for testing; conditional logic disables desktop-only features
+
+## Anti-Patterns
+
+### Mutable Widget State Without Rebuild Trigger
+
+**What happens:** Some cubits/providers emit but listeners don't rebuild (e.g., manually modifying list without emit).
+
+**Why it's wrong:** UI becomes stale; user sees outdated data; difficult to debug.
+
+**Do this instead:** Always emit a new state after data mutations in cubits. Use copyWith() to create new instances. Example: `emit(state.copyWith(coins: [...state.coins, newCoin]))` in `WalletDetailsCubit`.
+
+### Direct FFI Calls on Main Thread
+
+**What happens:** Long-running FFI operations (wallet creation, signing) block UI if called directly from BLoC.
+
+**Why it's wrong:** UI jank, frozen app, poor UX.
+
+**Do this instead:** Wrap FFI calls in async/await; use Isolate.spawn() for heavy operations if needed. GeniusApi already handles this via GeniusSDK async interface.
+
+### Hardcoded Network/Coin Data
+
+**What happens:** Network chains and token lists embedded in code (was done for testing).
+
+**Why it's wrong:** Difficult to update without recompile; no dynamic network addition.
+
+**Do this instead:** Load from assets (JSON) via NetworkProvider and NetworkTokensProvider. See `lib/assets/read_asset.dart`.
+
+## Error Handling
+
+**Strategy:** Defensive: try-catch in services, emit error state in cubits, show user-facing toast/dialog
+
+**Patterns:**
+- **Service Layer:** BanxaApiService, CoinGeckoApi wrap HTTP calls in try-catch, throw custom exceptions or return null
+- **BLoC/Cubit:** Catch exceptions, emit error status (e.g., `OrdersStatus.error`), caller checks status and renders error UI
+- **UI Layer:** BlocListener catches errors, shows Toast via ToastManager or bottom drawer
+- **Sentry Integration:** Global exception handler in main.dart captures crashes, logs to Sentry
+
+Example (lib/banxa/banxa_order/banxa_order_cubit.dart:9-33):
+```dart
+Future<void> fetchOrders(String? externalCustomerId) async {
+  emit(state.copyWith(status: OrdersStatus.loading, error: ''));
+  try {
+    final orders = await BanxaApiService().fetchAllOrders(...);
+    emit(state.copyWith(status: OrdersStatus.success, orders: orders));
+  } catch (e) {
+    emit(state.copyWith(status: OrdersStatus.error, error: e.toString()));
+  }
+}
+```
+
+## Cross-Cutting Concerns
+
+**Logging:**
+- Approach: debugPrint() in Dart (console only); Sentry for production errors
+- No persistent app logging framework; SDK logs in separate sgnslog.log (managed by native GeniusSDK)
+
+**Validation:**
+- Approach: Inline checks in cubits/services (wallet address format, amount > 0, etc.)
+- No centralized validator; each feature validates its inputs
+
+**Authentication:**
+- Approach: N/A for this wallet (no user accounts); wallets authenticated via private key/mnemonic
+- SGNUS connection managed by SDK; WalletConnect (Reown) handled by reown_walletkit package
+
+**Responsive Design:**
+- Approach: LayoutBuilder + MediaQuery + GeniusBreakpoints utility
+- Mobile (<768px): MobileOverlay (bottom nav), single column layout
+- Tablet/Desktop (>768px): DesktopOverlay (side nav or top nav), multi-column grid
+
+---
+
+*Architecture analysis: 2026-07-15*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,296 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-07-15
+
+## Tech Debt
+
+### Hardcoded Bridge Configuration
+
+**Issue:** Bridge destination chain ID hardcoded in two locations
+- Files: `lib/submit_job/cubit/submit_job_cubit.dart` (lines 142, 189)
+- Impact: Cannot support multiple bridge destinations; requires code change for network updates
+- Fix approach: Move to configurable network settings from `selectedNetwork` or a bridge config service
+- Severity: HIGH - Blocks multi-chain bridge support
+
+### Event Parameter Refactoring Needed
+
+**Issue:** `WalletSecurityEntered` event has 5 separate parameters that should be grouped
+- Files: `lib/onboarding/existing_wallet/bloc/existing_wallet_event.dart` (lines 14-32)
+- Impact: Verbose API, error-prone when passing multiple params, hard to extend
+- Fix approach: Create a single `SecurityConfig` or `ImportConfig` object
+- Severity: LOW - Code maintainability issue
+
+### Incomplete Chain/Network Configuration
+
+**Issue:** Hardcoded chain references instead of dynamic discovery
+- Files: `lib/squid_router/squid_token_service.dart` (line 85 TODO)
+- Impact: Manual updates required when networks change; hardcoded asset list in `assets/networks.json`
+- Fix approach: Implement dynamic chain/network discovery from API
+- Severity: MEDIUM - Operational burden
+
+## Error Handling & Logging
+
+### Silent Exception Swallowing
+
+**Issue:** Multiple catch blocks with underscore (_) that emit generic error states without logging root cause
+- Files:
+  - `lib/bloc/app_bloc.dart` (lines 154, 169, 188) - FetchAccount, CheckIfUserExists, processing timer
+  - `lib/components/sgnus/sgnus_connection_widget.dart` - Silent catch
+  - `lib/banxa/handle_banxa_drawer.dart` - Silent exception in transaction handling
+- Impact: Debugging difficult; users see generic "error" with no context; loss of signal about actual failures
+- Fix approach: Log exception message and stacktrace with `debugPrint('❌ [Context]: $e\n$st')` before emitting error state
+- Severity: HIGH - Debugging and support burden
+
+### Print Statements Instead of debugPrint
+
+**Issue:** 26+ `print()` calls in production code instead of `debugPrint()`
+- Files: Concentrated in `lib/banxa/banxa_api_services.dart` (13+ instances), also in `lib/web/web_view_mobile.dart`, `lib/tokeninfo/token_info_loader.dart`, `lib/banxa/banxa_order/create_order_cubit.dart`
+- Impact: Logs persist in release builds; noise in production; potential security info leak (URLs, order details)
+- Fix approach: Replace all `print(` with `debugPrint(` or use structured logging
+- Severity: MEDIUM - Hygiene, potential security/performance
+
+### TODO Comments Without Tracking
+
+**Issue:** 11+ TODO comments scattered in code without issue tracking or priority
+- Files:
+  - `lib/squid_router/squid_token_service.dart:85` - Add chains dynamically
+  - `lib/squid_router/swap_screen.dart:353,365` - Invoke Squid API, record transaction
+  - `lib/reown/handle_dapp_requests.dart:138,141,163,164` - Parse tx data, confirm network, show pending tx, record coin symbol
+  - `lib/submit_job/cubit/submit_job_cubit.dart:142,189` - Unhardcode bridge address
+  - `lib/onboarding/existing_wallet/bloc/existing_wallet_event.dart:15` - Refactor into object
+  - `lib/onboarding/existing_wallet/view/select_wallet_type_screen.dart:12` - Support other networks
+- Impact: Unclear priority; unclear if they block features or are nice-to-haves; no assignment
+- Fix approach: Create JIRA/issue tickets or link to them in code (e.g., `// GNUS-123: Dynamic chain support`)
+- Severity: MEDIUM - Process/priority
+
+## Security Considerations
+
+### Recovery Phrase Handling
+
+**Issue:** Seed phrase (recovery words) kept in unencrypted BLoC state in memory; can be copied to clipboard
+- Files: `lib/onboarding/new_wallet/bloc/new_wallet_state.dart`, `lib/onboarding/new_wallet/view/recovery_phrase_screen.dart` (lines 104, 125)
+- Current mitigation: Visual toggle to hide/show; clipboard copy without OS confirmation
+- Risk:
+  - Memory dump could expose recovery words
+  - Clipboard accessible by other apps on most Android versions (pre-Android 10)
+  - No additional user confirmation before clipboard copy
+- Recommendations:
+  - Add explicit user confirmation ("Are you sure?") before copy-to-clipboard
+  - Use native clipboard APIs where possible to leverage OS protections
+  - Consider never exposing full phrase; use numbered grid only
+  - Implement memory wiping after use (though Dart's GC makes this difficult)
+- Severity: CRITICAL - Core wallet security
+
+### Private Key Management in FFI Boundary
+
+**Issue:** Private keys converted to hex strings for passing to native GeniusSDK via FFI
+- Files: `packages/genius_api/lib/src/genius_api.dart` (lines 227-241)
+- Current mitigation: String is allocated via `toNativeUtf8()` and freed via `malloc.free()`
+- Risk:
+  - Hex string representation in memory longer than binary form
+  - String may linger in Dart's string pool
+  - No cryptographic zeroization guarantee
+- Recommendations:
+  - Verify native FFI functions properly zeroize input buffers
+  - Implement custom Uint8List zeroization helper before/after FFI calls
+  - Consider Securable uint8 FFI types (if available in packages)
+- Severity: HIGH - Direct key exposure vector
+
+### JavaScript Injection in WebView
+
+**Issue:** Hardcoded JavaScript code injected into WebView to force dark mode and remove Uniswap banner
+- Files: `lib/web/web_view_mobile.dart` (lines 58-115)
+- Current mitigation: Script is hardcoded; not user-provided data
+- Risk:
+  - If webview URL is user-controlled, could allow XSS
+  - Modifying page DOM and localStorage affects Uniswap behavior
+- Recommendations:
+  - Validate that URL domain is whitelisted before injecting any JS
+  - Consider using CSS injection or WebView platform channel instead
+  - Document that this only runs on `uniswap.org`
+- Severity: MEDIUM - Depends on URL source validation
+
+### WalletConnect Request Handling
+
+**Issue:** Hardcoded "ETH" coin symbol in WalletConnect transaction handling
+- Files: `lib/reown/handle_dapp_requests.dart` (line 139, 164)
+- Risk: User may approve transaction in one token but record/display as ETH
+- TODO Comments also indicate:
+  - Transaction data parsing not implemented (line 138)
+  - Network validation not implemented (line 141)
+- Fix approach: Parse `tx.data` for token contract and amount; validate chainId matches user's selected network
+- Severity: HIGH - User confusion, potential loss
+
+## Performance Bottlenecks
+
+### Aggressive Polling Intervals
+
+**Issue:** 5-second polling on order status; multiple 1-minute refresh intervals
+- Files:
+  - `lib/banxa/banxa_order/polling_order_cubit.dart:19` - Order status polling every 5 seconds
+  - `lib/chart/crypto_live_chart.dart:81` - Chart refresh every 1 minute
+  - `lib/components/coins/view/coins_screen.dart:44` - Coins list refresh every 1 minute
+- Impact: Battery drain on mobile; repeated API calls even if data unchanged; server load
+- Improvement path:
+  - Implement exponential backoff after no-change responses
+  - Add user-configurable refresh rate (with default of 5+ minutes for non-critical data)
+  - Use WebSocket or server-sent events for real-time updates instead of polling
+  - Clear timers when screen is backgrounded
+- Severity: MEDIUM - User experience, battery life
+
+### Per-Rebuild Refetch Pattern
+
+**Issue:** Dashboard calls `walletCubit.getCoins()` in `initState` within a `addPostFrameCallback`
+- Files: `lib/dashboard/home/view/dashboard_screen.dart:35-41`
+- Risk: If dashboard rebuilds for other reasons, getCoins() may be called again unnecessarily
+- Fix approach: Use a `mounted` check or BLoC event deduplication; or move fetch to router redirect (already done for wallets)
+- Severity: LOW - Minimal if getCoins() is already deduplicated internally
+
+### Large UI Files
+
+**Issue:** Single screen exceeds 726 lines
+- Files: `lib/dashboard/bridge/bridge_screen.dart` (726 lines)
+- Impact: Hard to navigate; multiple concerns mixed; refactoring risk
+- Fix approach: Extract sub-widgets and cubits into separate files (e.g., `bridge_form.dart`, `bridge_status.dart`)
+- Severity: MEDIUM - Maintainability
+
+## Code Quality Issues
+
+### Analyzer Blind Spots
+
+**Issue:** `analysis_options.yaml` excludes `*.g.dart` files (generated code)
+- Files: `.planning/codebase/analysis_options.yaml` (line 5)
+- Impact: Broken generated widgets (e.g., `@freezed`, `@JsonSerializable`) not caught during analysis
+- Risk: Type errors in generated code, incompatible API changes to generators not detected
+- Recommendation: 
+  - Run analyzer on `*.g.dart` files in CI only (expensive but catches generator bugs)
+  - Or: Keep exclusion but ensure regeneration is part of CI before commit
+- Severity: MEDIUM - Hidden bugs
+
+### Unsafe Casts in JSON Deserialization
+
+**Issue:** Multiple `as` casts without null-coalescing in banxa_model.dart
+- Files: `lib/banxa/banxa_model.dart` (lines 264-320)
+- Pattern: `json['field'] as String` will throw if field is null
+- Recommendation: Use `json['field'] as String?` or `?? ''` for safety
+- Severity: LOW - Mostly safe if JSON validated upstream, but fragile
+
+### Missing Null Checks
+
+**Issue:** Navigator.of(context) called without null check in reown request handler
+- Files: `lib/reown/handle_dapp_requests.dart:108` - `navigatorKey.currentContext!`
+- Risk: Will crash if router not yet initialized or context popped
+- Fix: Use navigatorKey.currentContext?. and check for null before showing drawer
+- Severity: MEDIUM - Runtime crash if triggered
+
+## Fragile Areas
+
+### WalletConnect Implementation
+
+**Files:** `lib/reown/`
+
+**Why fragile:**
+- Multiple TODOs indicate incomplete feature gates (network validation, tx parsing, pending UI)
+- Duplicate request detection via `pendingRequestIds` set is in-memory only (lost on app restart)
+- No timeout for pending approvals; drawer could be left open indefinitely
+
+**Safe modification:**
+- Add request timeout (e.g., 5 min, then auto-reject)
+- Persist `pendingRequestIds` to local storage
+- Implement transaction data parsing in separate, testable function
+- Add unit tests for request deduplication
+
+**Test coverage:** No visible WalletConnect-specific tests in codebase
+
+### Secure Storage Initialization
+
+**Files:** `packages/local_secure_storage/lib/src/local_secure_storage_base.dart`
+
+**Why fragile:**
+- `init()` method iterates all keys and validates them; if there are many wallets, could hang
+- Errors during `init()` are logged but not propagated; init could silently fail
+- If StoredKey.importJson() throws, key is deleted without user consent
+
+**Safe modification:**
+- Wrap init in timeout (e.g., 30 sec)
+- Add progress callback for large key sets
+- Log deletion events explicitly
+- Add recovery path if init fails
+
+**Test coverage:** No visible tests
+
+### FFI Bridge
+
+**Files:** `packages/genius_api/lib/ffi_bridge_prebuilt.dart`, `lib/src/genius_api.dart`
+
+**Why fragile:**
+- `FFIBridgePrebuilt()` silently returns if DynamicLibrary.open() fails; `_ffiBridgePrebuilt.sgns_lib` will be uninitialized
+- Late initialization: `_address` and `_basePath` are `late` vars; accessing before `_initSDK()` completes will throw `LateInitializationError`
+- No guard against double-initialization (though `_isSdkInitialized` flag helps)
+
+**Safe modification:**
+- Throw or return error in FFIBridgePrebuilt if load fails; don't silently return
+- Add safety checks before accessing late vars; use `_isSdkInitialized` guard
+- Add integration tests for FFI initialization flow
+- Document that `initSDK()` must be called before any FFI calls
+
+**Test coverage:** Minimal; mostly happy-path
+
+## Scaling Limits
+
+### Memory Usage of in-Memory State
+
+**Issue:** BLoC state holds lists of wallets, transactions, recovery words, all in memory
+- Files: Multiple BLoCs in `lib/bloc/`, `lib/banxa/banxa_order/`, etc.
+- Current capacity: Unknown; likely fine for <100 wallets/1000 transactions, but not tested
+- Limit: Large transaction history (1000+) could cause OOM on low-end Android devices
+- Scaling path:
+  - Paginate transactions (load first 50, lazy-load on scroll)
+  - Use Hive database queries instead of in-memory lists
+  - Implement transaction caching strategy (only keep last N days in memory)
+
+### API Rate Limiting
+
+**Issue:** No visible rate-limiting or retry backoff logic
+- Files: `lib/banxa/banxa_api_services.dart`, `lib/dashboard/home/`
+- Risk: Banxa/Squid/external APIs could rate-limit or block on high activity
+- Scaling path: Implement exponential backoff with jitter; cache responses where possible
+
+## Missing Critical Features
+
+### Transaction Data Parsing from WalletConnect
+
+**Issue:** Token swap amounts and symbols not parsed from eth_sendTransaction data field
+- Files: `lib/reown/handle_dapp_requests.dart:138` (TODO comment)
+- Impact: User sees only amount in Wei, not token name/decimals; hardcoded "ETH" symbol
+- Blocks: Proper swap confirmation UI; accurate transaction recording
+
+### Network Validation for Swap Confirmation
+
+**Issue:** No validation that dApp-requested network matches user's selected wallet network
+- Files: `lib/reown/handle_dapp_requests.dart:141` (TODO comment)
+- Impact: User could approve ETH transaction on Polygon network, leading to confusion/loss
+- Blocks: Safe WalletConnect signing
+
+### Pending Transaction UI
+
+**Issue:** After signing WalletConnect transaction, transaction immediately marked as completed without waiting for block confirmation
+- Files: `lib/reown/handle_dapp_requests.dart:165-172`
+- Impact: User sees success before tx is actually included in block; could be misleading
+- Fix: Use pending status and update from blockchain confirmation
+
+## Disabled CTA Contrast Issues
+
+**Issue:** Disabled button text/background contrast may not meet WCAG AA standards
+- Files: `lib/theme/theme.dart` (lines 120-127), `lib/theme/genius_wallet_colors.dart` (line 15)
+- Current: Background `Colors.grey.shade900` (very dark), foreground `colorScheme.onSurfaceVariant` (grey)
+- Risk: Users with visual impairments cannot see disabled state; violates accessibility guidelines
+- Fix approach:
+  - Use higher contrast color for disabled foreground (lighter grey)
+  - Test with contrast checker (WCAG AA requires 4.5:1 for text)
+  - Consider different background for disabled state (e.g., darker surface with border)
+- Severity: MEDIUM - Accessibility issue
+
+---
+
+*Concerns audit: 2026-07-15*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,360 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-07-15
+
+## Naming Patterns
+
+**Files:**
+- Snake case: `lib/bloc/pin_cubit.dart`, `lib/components/coins/view/coin_card_row.dart`
+- Directory hierarchy follows feature structure: `lib/[feature]/[type]/`
+
+**Classes/Types:**
+- Pascal case: `PinCubit`, `CoinCardRow`, `NewWalletBloc`, `GeniusWalletColors`
+- Widget classes: `CoinCardRow`, `CoinTableRow` (describe UI component)
+- Bloc/Cubit: `PinCubit`, `NewWalletBloc`, `GnusCubit` (suffix with Bloc/Cubit)
+- State classes: `PinState`, `NewWalletState` (suffix with State)
+- Event classes: `RecoveryPhraseContinue`, `RecoveryWordTapped` (verb phrases)
+- Enums: `PinFullness`, `VerificationStatus`, `SavePinStatus`
+
+**Functions/Methods:**
+- Camel case: `clearAll()`, `add()`, `verifyPin()`, `desktopOnChanged()`
+- Private methods prefix with underscore: `_onRecoveryPhraseContinue()`, `_showAddWithMnemonicDialog()`
+- Boolean getters/predicates: `pinExists()`, `noBalance` (natural language)
+
+**Variables:**
+- Camel case: `pinMaxLength`, `textController`, `displayIncorrectPin`, `pinController`
+- Constants (within classes): `static const String _partnerCode = 'gnus'`
+- Theme/design tokens: Static class properties in `GeniusWalletColors`, `GeniusWalletConsts`
+
+**Imports:**
+- Path aliases: None observed; uses relative imports within features
+
+## Code Style
+
+**Formatting:**
+- Tool: No explicit tool configured (relies on IDE default + Dart formatter)
+- Page width: 80 characters (set in `analysis_options.yaml`)
+- Indentation: 2 spaces
+
+**Linting:**
+- Primary: `flutter_lints` ^6.0.0 (uses `package:flutter_lints/flutter.yaml`)
+- Fallback: `lints` ^6.1.0
+- Configuration: `analysis_options.yaml` at root; `lints/recommended.yaml` in packages
+- Exclusions: Generated files excluded (`lib/**/*.g.dart`, `lib/**/*.freezed.dart`)
+
+**Linting File Organization:**
+```yaml
+# Main app (analysis_options.yaml)
+include: package:flutter_lints/flutter.yaml
+analyzer:
+  exclude:
+    - lib/**/*.g.dart
+    - lib/**/*.freezed.dart
+    - banxa
+    - squidrouter
+    - packages/genius_api/lib/proto
+formatter:
+  page_width: 80
+
+# Packages (genius_api/analysis_options.yaml)
+include: package:lints/recommended.yaml
+formatter:
+  page_width: 80
+```
+
+**Ignore Comments:**
+- Used where needed: `// ignore_for_file: avoid_print`
+- Lint suppressions: `// ignore: unused_element`
+
+## Import Organization
+
+**Order:**
+1. Dart standard library: `import 'dart:async'`, `import 'dart:convert'`
+2. Flutter framework: `import 'package:flutter/material.dart'`
+3. External packages: `import 'package:flutter_bloc/flutter_bloc.dart'`
+4. Local packages (monorepo): `import 'package:genius_api/genius_api.dart'`
+5. Local project imports: `import 'package:genius_wallet/bloc/pin_state.dart'`
+
+**Example:**
+```dart
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:genius_api/genius_api.dart';
+
+import 'package:genius_wallet/bloc/pin_state.dart';
+import 'package:genius_wallet/utils/image_utils.dart';
+```
+
+## Error Handling
+
+**Patterns:**
+- **Try/catch with underscore:** Catch unused exceptions with `_` variable name
+  ```dart
+  try {
+    final account = await api.getAccount();
+    emit(state.copyWith(accountStatus: AppStatus.loaded, account: account));
+  } catch (_) {
+    emit(state.copyWith(accountStatus: AppStatus.error));
+  }
+  ```
+
+- **Explicit exception throwing:**
+  ```dart
+  if ((fiatAmount == null || fiatAmount.isEmpty) &&
+      (cryptoAmount == null || cryptoAmount.isEmpty)) {
+    throw ArgumentError('Either fiatAmount or cryptoAmount must be provided.');
+  }
+  ```
+
+- **Null returns for recoverable errors:**
+  ```dart
+  try {
+    final response = await http.post(url, headers: _headers, body: jsonEncode(kycData));
+    if (response.statusCode == 200) {
+      return BanxaKycResponse.fromJson(jsonDecode(response.body));
+    } else {
+      print('Banxa KYC failed: ${response.body}');
+      return null;
+    }
+  } catch (e) {
+    print('Banxa KYC error: $e');
+    return null;
+  }
+  ```
+
+**Error Reporting:** Sentry integration at app level (`lib/main.dart`). Errors logged via `debugPrint()` for debug builds, print() for API errors.
+
+## Logging
+
+**Framework:** 
+- `debugPrint()` for debug output (shown only in debug builds)
+- `print()` for API/service errors (rare, used in `BanxaApiService`)
+
+**Patterns:**
+- Debug output with emoji prefixes:
+  ```dart
+  debugPrint('⚠️ Error fetching native token for ${network.name}: $e');
+  debugPrint('❌ Could not find token ${tokenContract.name}, skipping');
+  debugPrint('🧭 Received deep link: $uri');
+  debugPrint('📍 Navigating to: $fullPath');
+  ```
+
+**When to log:**
+- Errors in services/repositories
+- Entry/exit points of critical operations (deep links, navigation)
+- State transitions (rarely necessary in bloc)
+
+**Sentry:** Error tracking via `sentry_flutter` ^9.0.0, configured in `main()` with custom `beforeSend` filter.
+
+## Comments
+
+**When to Comment:**
+- Non-obvious algorithm or state logic
+- Workarounds or temporary fixes
+- Integration points with external systems
+
+**JSDoc/TSDoc Pattern:**
+- Use `///` for doc comments on public APIs
+- Single `//` for inline explanations
+- Rare in event/state classes; used in API/business logic
+
+**Example:**
+```dart
+/// Verifies [pin] with the user-set pin
+Future<void> verifyPin() async {
+  final pin = _textController.text;
+  final isVerified = await geniusApi.verifyUserPin(pin);
+  
+  if (isVerified) {
+    emit(state.copyWith(verificationStatus: VerificationStatus.pass));
+  } else {
+    pinConfirmFailed();
+  }
+}
+
+/// Event thrown when the user acknowledges the recovery phrase they received
+class RecoveryVerificationContinue extends NewWalletEvent {}
+```
+
+## Function Design
+
+**Size:** Keep functions under 50 lines; extract private helpers for complex logic.
+
+**Parameters:** 
+- Named parameters: `final TextEditingController _textController => state.pinController.textController;`
+- Use `required` keyword for mandatory params
+- Default values for optional params
+
+**Return Values:**
+- Future-based for async operations: `Future<void>`, `Future<BanxaKycResponse?>`
+- Sync operations: Direct returns or null
+- Bloc event handlers: void (use emit for state changes)
+
+**Example from `PinCubit`:**
+```dart
+class PinCubit extends Cubit<PinState> {
+  final int pinMaxLength;
+  final GeniusApi geniusApi;
+  
+  PinCubit({required this.pinMaxLength, required this.geniusApi})
+    : super(PinState(pinController: PinInputController()));
+
+  void clearAll() {
+    _textController.clear();
+    emit(state.copyWith(
+      pinController: state.pinController,
+      pinFullness: PinFullness.inProgress,
+    ));
+  }
+}
+```
+
+## Module Design
+
+**Exports:** 
+- Barrel files not consistently used; direct imports preferred
+- Example: `import 'package:genius_api/genius_api.dart'` for package-level exports
+
+**Bloc/Cubit Organization:**
+- Event, State, Bloc in separate files or as `part` of bloc file
+- Pattern in `NewWalletBloc`:
+  ```dart
+  // new_wallet_bloc.dart
+  part 'new_wallet_event.dart';
+  part 'new_wallet_state.dart';
+  
+  class NewWalletBloc extends Bloc<NewWalletEvent, NewWalletState> {
+    // ...
+  }
+  ```
+
+**State/Cubit Immutability:**
+- Use `copyWith()` for state immutability
+- States extend `Equatable` for value equality
+- Example:
+  ```dart
+  class PinState {
+    final PinInputController pinController;
+    final bool displayIncorrectPin;
+    
+    PinState copyWith({
+      PinInputController? pinController,
+      bool? displayIncorrectPin,
+    }) {
+      return PinState(
+        pinController: pinController ?? this.pinController,
+        displayIncorrectPin: displayIncorrectPin ?? this.displayIncorrectPin,
+      );
+    }
+  }
+  ```
+
+## Serialization & Generated Code
+
+**Hive (Local Storage):**
+- Decorator: `@HiveType(typeId: 0)`
+- Fields: `@HiveField(0)` with type ID
+- Manual serialization: `fromJson()` factory and `toJson()` method
+- Example:
+  ```dart
+  @HiveType(typeId: 0)
+  class CoinGeckoCoin {
+    @HiveField(0)
+    final String id;
+    
+    factory CoinGeckoCoin.fromJson(Map<String, dynamic> json) => CoinGeckoCoin(
+      id: json['id'] ?? '',
+    );
+    
+    Map<String, dynamic> toJson() => {'id': id};
+  }
+  ```
+
+**Freezed (Immutable Models):**
+- Used in `packages/genius_api` for API models
+- Decorator: `@freezed` with `abstract class Model with _$Model`
+- Auto-generates `fromJson()` and `toJson()`
+- Example:
+  ```dart
+  @freezed
+  abstract class Coin with _$Coin {
+    const factory Coin({
+      String? name,
+      String? symbol,
+      String? address,
+    }) = _Coin;
+    
+    factory Coin.fromJson(Map<String, Object?> json) => _$CoinFromJson(json);
+  }
+  ```
+
+**FFI Bindings (Native Code):**
+- Generated by `ffigen` ^20.1.1
+- File: `packages/genius_api/lib/ffi/genius_api_ffi.dart`
+- Pattern: Auto-generated, do not edit manually
+- Comments: Preserve C function documentation as-is
+- Example binding:
+  ```dart
+  // AUTO GENERATED FILE, DO NOT EDIT.
+  // Generated by `package:ffigen`.
+  ffi.Pointer<ffi.Char> GeniusSDKInit(
+    ffi.Pointer<ffi.Char> base_path,
+    ffi.Pointer<ffi.Char> dev_config,
+  ) {
+    return _GeniusSDKInit(base_path, dev_config);
+  }
+  ```
+
+## Router Patterns
+
+**GoRouter Configuration:**
+- Location: `lib/navigation/router.dart`
+- Route definition: `GoRoute(path: '/path', builder: (context, state) => Widget())`
+- Extra data passing: `state.extra as Map<String, dynamic>?`
+- Redirect guards: Checked in router's `redirect` callback
+
+**Example:**
+```dart
+final geniusWalletRouter = GoRouter(
+  navigatorKey: navigatorKey,
+  redirect: (context, state) {
+    final appBloc = context.read<AppBloc>();
+    if (appBloc.state.sdkStatus == AppStatus.initial) {
+      appBloc.add(InitializeSDK());
+    }
+    return null;
+  },
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const Splash(),
+    ),
+  ],
+);
+```
+
+## Theme & Design Tokens
+
+**Location:** `lib/theme/` 
+- `genius_wallet_colors.dart`: Color constants
+- `genius_wallet_consts.dart`: Size, padding constants (likely)
+- `genius_wallet_gradient.dart`: Gradient definitions
+
+**Pattern:**
+```dart
+class GeniusWalletColors {
+  static const Color lightGreenPrimary = Colors.greenAccent;
+  static const Color deepBlueTertiary = Color(0xff05090F);
+  
+  static Color btnFilterSelected = lightGreenPrimary.withValues(alpha: 0.1);
+}
+```
+
+**Usage:** Access via class properties (`GeniusWalletColors.lightGreenPrimary`) or Material ColorScheme from `Theme.of(context).colorScheme`.
+
+---
+
+*Convention analysis: 2026-07-15*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,257 @@
+# External Integrations
+
+**Analysis Date:** 2026-07-15
+
+## APIs & External Services
+
+**Fiat On-Ramp:**
+- Banxa - Fiat currency to crypto on-ramp service
+  - Endpoint: `https://api.banxa.com/gnus/v2`
+  - Sandbox: `https://gnus.banxa-sandbox.com`
+  - SDK/Client: Custom HTTP integration via `http` package
+  - Auth: API key + HMAC-SHA256 signature authentication
+  - Implementation: `lib/banxa/banxa_api_services.dart`
+    - Partner code: `gnus`
+    - API Key stored in code (needs env var migration)
+  - Features: KYC submission, order creation, payment processing
+  - Deep link support: `geniuswallet://banxa/callback`
+  - Components: `lib/banxa/` (models, services, UI, order history)
+
+**Cross-Chain Swaps:**
+- Squid Router - Cross-chain token swap aggregator
+  - Mainnet: `https://api.squidrouter.com/v1`
+  - Testnet: `https://testnet.api.squidrouter.com/v1`
+  - SDK/Client: Custom HTTP integration via `http` package
+  - Auth: No auth required (public API)
+  - Implementation: `lib/squid_router/squid_token_service.dart`
+  - Features:
+    - Token listing across chains
+    - Balance checking
+    - Route calculation
+    - Swap execution
+  - Components: `lib/squid_router/` (swap screen, models, token service)
+
+**Market Data:**
+- CoinGecko - Cryptocurrency price and market data
+  - Endpoint: `https://api.coingecko.com/api/v3`
+  - SDK/Client: Custom HTTP integration via `http` package
+  - Auth: No auth required (free tier)
+  - Implementation: `lib/services/coin_gecko/coin_gecko_api.dart`
+  - Caching: Hive cache with 3-minute TTL
+  - Features:
+    - Historical price data (1-day charts)
+    - Market data for multiple coins
+  - Storage: Cached in Hive boxes:
+    - `coinGeckoCacheBox` - Coin metadata
+    - `marketDataBox` - Market data
+    - `historicalPricesBox` - Historical prices with timestamps
+
+**Cryptocurrency News:**
+- CoinTelegraph - News aggregation
+  - Implementation: `lib/services/coin_telegraph/`
+  - Caching: Hive cache for news articles
+  - Storage: `coinTelegraphNewsBox`, `coinTelegraphTimestampBox`
+
+**Blockchain RPCs:**
+- DRPC (Distributed RPC) - Multi-chain RPC provider
+  - Used for: Ethereum, Polygon, BSC, Base mainnet
+  - Endpoint pattern: `https://{network}.drpc.org`
+  - Configuration: `assets/json/networks/networks.json`
+
+- Chainstack - RPC provider for testnet support
+  - Used for: Polygon Amoy (testnet), BSC Testnet, Base Sepolia
+  - Configuration: `assets/json/networks/networks.json`
+
+**Wallet Connection & dApp Support:**
+- Reown/WalletConnect (v2) - Universal wallet connection protocol
+  - SDK/Client: `reown_walletkit ^1.3.2`
+  - Project ID: `999123e54f32a21dbd087339746231b1`
+  - Implementation: `lib/reown/reown_walletkit_instance.dart`
+  - Wallet metadata:
+    - Name: `Gnus.ai Wallet`
+    - URL: `https://gnus.ai/`
+    - Description: `Gnus.ai wallet`
+  - Features:
+    - dApp connection approval
+    - Transaction signing for dApps
+    - Session management
+  - Components: `lib/reown/` (connection, transaction approval, utilities)
+
+**Blockchain Interaction:**
+- web3dart 3.0.0+ - EVM (Ethereum-compatible) blockchain interaction
+  - SDK/Client: `web3dart ^3.0.0`
+  - Implementation: `packages/genius_api/lib/web3/`
+  - Supports: Ethereum, Polygon, BSC, Base, Arbitrum, Optimism, and any EVM chain
+  - Features: Contract interaction, transaction signing, state queries
+
+**Native Blockchain SDK:**
+- GeniusSDK - Custom native SDK for blockchain operations
+  - Integration: Dart FFI in `packages/genius_api/`
+  - FFI Bindings: `packages/genius_api/lib/ffi/genius_api_ffi.dart`
+  - Native Bridge: `packages/genius_api/lib/src/genius_api.dart`
+  - SGNUS Connection: Custom protocol for Genius blockchain
+  - Configuration: `assets/sgns_config.json`
+  - Build: Windows CMake integration via `windows/CMakeLists.txt`
+  - Components:
+    - Controllers: `packages/genius_api/lib/controllers/`
+    - Models: `packages/genius_api/lib/models/`
+    - Extensions: `packages/genius_api/lib/extensions/`
+
+**Trust Wallet Integration:**
+- Trust Wallet Core FFI - Optional TrustWallet SDK binding
+  - Implementation: `packages/genius_api/lib/ffi/trust_wallet_api_ffi.dart`
+  - Status: Built but may not be actively used
+
+## Data Storage
+
+**Local Database:**
+- Hive (Encrypted, v2.19.3+) - NoSQL embedded database for caching
+  - Package: `hive_ce` (community edition with encryption)
+  - Flutter integration: `hive_ce_flutter 2.3.4`
+  - Storage location: `getApplicationDocumentsDirectory()/hive/`
+  - Boxes:
+    - `coinGeckoCacheBox` - CoinGecko coin metadata
+    - `marketDataBox` - Market data with timestamps
+    - `historicalPricesBox` - Price history (keyed by coin ID)
+    - `coinTelegraphNewsBox` - News articles
+    - `coinTelegraphTimestampBox` - News cache timestamps
+    - `walletBoxName` - Wallet data (address, keys, metadata)
+    - `networkBoxName` - Network configuration
+    - Transaction boxes (direction, status, type, recipients, transactions)
+  - Initialization: `lib/hive/init.dart` - `initHive()` function
+  - Type adapters auto-generated by `hive_ce_generator`
+
+**Secure Storage:**
+- flutter_secure_storage 9.2.4 - Platform-specific secure storage
+  - iOS: Keychain
+  - Android: Encrypted SharedPreferences / Keystore
+  - Windows/macOS/Linux: File-based with platform-specific encryption
+  - Wrapper: `packages/local_secure_storage/` package
+  - Used for: Private keys, seed phrases, sensitive credentials
+
+**File Storage:**
+- path_provider 2.1.6 - Access to application directories
+  - SDK logs: `getApplicationDocumentsDirectory()/sgnslog.log`, `sgnslog2.log`
+  - Sentry integration: Logs attached to error reports
+
+## Authentication & Identity
+
+**Wallet Authentication:**
+- Custom implementation - Private key/seed phrase based
+  - Storage: Secure storage via `local_secure_storage`
+  - Types: Imported wallets, generated wallets
+  - No OAuth/external auth provider used
+
+**dApp Authentication:**
+- WalletConnect (Reown) - dApp connection and signing
+  - Pairing via QR codes or URI schemes
+  - Transaction approval flow
+  - Session persistence
+
+## P2P & Networking
+
+**Bootstrap Nodes:**
+- IPFS bootstrap configuration in `assets/network_config.json`
+  - Multiple public IPFS nodes for p2p connectivity
+  - UPnP support enabled
+  - DHT (Distributed Hash Table) auto-discovery enabled
+  - Connection pooling: High water mark (300), low water mark (150)
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- Sentry (9.0.0) - Error reporting and performance monitoring
+  - DSN: `https://5a5e942557e461b7f464127e987cab08@o4511215700017152.ingest.us.sentry.io/4511215701458944`
+  - Implementation: `lib/main.dart` - `SentryFlutter.init()`
+  - Configuration:
+    - Trace sampling: 100% (all requests)
+    - Send PII: Enabled (include user data in reports)
+    - SDK logs attached: SGNUS logs auto-attached to crash reports
+    - Filtering: Error and fatal level events sent automatically
+  - Features: Exception tracking, performance monitoring, source maps
+
+**Logs:**
+- Console logging: Flutter `debugPrint()` throughout codebase
+- File logging: SGNUS SDK generates `sgnslog.log`, `sgnslog2.log`
+- Sentry attachment: SDK logs automatically attached to error reports
+
+**Analytics:**
+- Not configured (no Google Analytics, Mixpanel, or similar detected)
+
+## CI/CD & Deployment
+
+**Hosting:**
+- Multiplatform releases (see INSTALL.md):
+  - Windows: zip with `genius_wallet.exe`
+  - macOS: `.pkg` installer
+  - Linux x86_64: Gzipped tarball
+  - Linux aarch64: Gzipped tarball
+  - iOS: TestFlight
+  - Android: APK releases
+  - Web: Not actively promoted
+
+**CI Pipeline:**
+- GitHub Actions (inferred from `.github/` directory and release structure)
+  - No public CI config visible in main repo (may be in separate workflows)
+
+**Build Orchestration:**
+- Flutter CLI (via `flutter build <target>`)
+- Windows native: CMake with C++ compilation
+- Code generation: `build_runner` for Dart code gen
+
+## Environment Configuration
+
+**Required Environment Variables:**
+- `CMAKE_ARGUMENTS` (Windows build) - Passed to CMake for native build configuration
+- Banxa API key (currently hardcoded - security concern)
+- Network RPC URLs (in JSON config, not env vars)
+
+**Configuration Files:**
+- `assets/network_config.json` - P2P and IPFS settings
+- `assets/json/networks/networks.json` - Supported blockchains and RPC endpoints
+- `assets/json/tokens/` - Token metadata and icons
+- `assets/sgns_config.json` - SGNUS protocol configuration
+- `assets/dev_config.json` - Development mode settings
+- `assets/log_config.json` - Logging levels
+- `assets/crdt_config.json` - CRDT replication settings
+
+**Secrets Location:**
+- Banxa API key: Hardcoded in `lib/banxa/banxa_api_services.dart` (LINE 14)
+- Sentry DSN: Hardcoded in `lib/main.dart` (LINE 72)
+- Reown Project ID: Hardcoded in `lib/reown/reown_walletkit_instance.dart` (LINE 12)
+- **SECURITY NOTE**: API keys and DSNs should be moved to environment variables or secure build configuration
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- Deep link handler: `geniuswallet://banxa/callback` (Banxa order callback)
+  - Implementation: `lib/banxa/banxa_helpers/deep_link_service.dart`
+  - Uses: `app_links 7.0.0` for deep link detection
+
+**Outgoing:**
+- Transaction submission: Chain RPC calls via web3dart
+- Swap submission: HTTP POST to Squid Router API
+- KYC submission: HTTP POST to Banxa sandbox
+
+## API Rate Limits & Quotas
+
+**CoinGecko:**
+- Free tier: No API key required, standard rate limiting applies
+- Caching: 3-minute TTL in Hive to minimize requests
+
+**Squid Router:**
+- Public API, rate limits apply per IP
+- No API key authentication required
+
+**Banxa:**
+- Rate limiting depends on partner tier
+- API key authentication required
+
+**RPC Providers (DRPC, Chainstack):**
+- DRPC: Free tier available, rate limited
+- Chainstack: Free tier available, rate limited
+- Network requests cached where applicable
+
+---
+
+*Integration audit: 2026-07-15*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,188 @@
+# Technology Stack
+
+**Analysis Date:** 2026-07-15
+
+## Languages
+
+**Primary:**
+- Dart 3.10.0+ - All Flutter application logic, BLoC state management, service layer
+- C++ - GeniusSDK native bindings via FFI (Windows/Linux desktop integration)
+
+**Secondary:**
+- CMake - Windows native build configuration
+
+## Runtime
+
+**Environment:**
+- Flutter 3.x (revision e3c29ec00c9c825c891d75054c63fcc46454dca1 on stable channel)
+- Dart SDK ^3.10.0
+
+**Package Manager:**
+- Pub (Dart/Flutter package manager)
+- Lockfile: `pubspec.lock` present
+
+## Frameworks
+
+**Core:**
+- Flutter 3.x - Cross-platform UI framework (Windows, macOS, Linux, iOS, Android, Web)
+
+**State Management:**
+- flutter_bloc 9.1.1 - BLoC pattern for state management via cubits and blocs
+  - Location: `lib/bloc/`, `lib/wallets/cubit/`, `lib/banxa/banxa_order/`, `lib/dashboard/transactions/cubit/`
+  - bloc_concurrency 0.3.0 - Concurrency handling for bloc events
+
+**Navigation:**
+- go_router 17.2.2 - Declarative routing system
+  - Location: `lib/navigation/router.dart`
+
+**Serialization:**
+- json_serializable 6.8.0 - JSON code generation for models
+- freezed 3.2.3 - Immutable model generation with union types
+- build_runner 2.4.9 - Code generation orchestrator
+
+**UI Components:**
+- auto_size_text 3.0.0 - Responsive text sizing
+- flutter_svg 2.0.17 - SVG rendering
+- font_awesome_flutter 11.0.0 - Icon library
+- fl_chart 1.2.0 - Chart visualization
+- flutter_staggered_grid_view 0.7.0 - Staggered grid layouts
+- qr_flutter 4.1.0 - QR code generation
+- loading_animation_widget 1.3.0 - Loading indicators
+- pin_code_fields 9.3.0 - PIN/code input UI
+- cached_network_image 3.4.1 - Optimized image loading
+- clipboard 3.0.14 - Clipboard operations
+
+**Dependency Injection:**
+- provider 6.1.2 - Service locator and state provider pattern
+
+**Local Storage:**
+- hive_ce 2.19.3 - Local NoSQL database for caching
+- hive_ce_flutter 2.3.4 - Flutter integration
+- hive_ce_generator 1.10.0 - Adapter code generation (dev)
+
+**HTTP & Networking:**
+- http 1.2.2 - HTTP client for API requests
+- connectivity_plus 7.0.0 - Network connectivity detection
+
+**Web Integration:**
+- webview_flutter 4.1.0 - Embedded WebView (mobile/web)
+- webview_windows 0.4.0 - WebView for Windows desktop
+- app_links 7.0.0 - Deep linking support
+- url_launcher 6.1.6 - URL/link launching
+
+**Blockchain & Cryptography:**
+- web3dart 3.0.0 - EVM interaction (Ethereum, Polygon, BSC, etc.)
+- crypto 3.0.6 - Cryptographic functions (HMAC, SHA-256, etc.)
+- wallet 0.0.13 - Wallet utilities (from Reown)
+
+**Reactive Programming:**
+- rxdart 0.27.7 - Reactive extensions for Dart
+
+**Device & Platform:**
+- window_manager 0.5.1 - Window management (desktop)
+- path_provider 2.1.6 - Application directory paths
+- file_picker 11.0.2 - File selection dialogs
+- permission_handler 12.0.1 - Runtime permission requests
+- device_preview 1.2.0 - Device preview for UI testing
+
+**Error Tracking & Monitoring:**
+- sentry_flutter 9.0.0 - Error reporting and performance monitoring
+
+**Utilities:**
+- equatable 2.0.5 - Value equality for models
+- timeago 3.7.0 - Relative time formatting (e.g., "2 hours ago")
+- intl 0.20.2 - Internationalization and formatting
+- html_unescape 2.0.0 - HTML entity decoding
+- xml 6.5.0 - XML parsing
+- protobuf 6.0.0 - Protocol Buffer support
+- convert 3.1.1 - Data format conversions
+- ffi 2.0.1 - Foreign Function Interface for native bindings
+
+**Screenshots & Testing:**
+- screenshot 3.0.0 - Screenshot capture for testing
+
+## Testing
+
+**Framework:**
+- test 1.24.1 - Dart testing framework
+- flutter_test (SDK) - Flutter widget testing
+
+**Mocking:**
+- mockito 5.0.0 - Mocking library for tests
+
+**Linting:**
+- flutter_lints 6.0.0 - Flutter lint rules
+- lints 6.1.0 - Dart lint rules
+
+## Code Generation
+
+**Tools:**
+- ffigen 20.1.1 - FFI binding generator (generates Dart FFI from C headers)
+- json_serializable 6.8.0 - Generates `.g.dart` files for JSON serialization
+- hive_ce_generator 1.10.0 - Generates Hive adapter code for type adapters
+
+**Configuration:**
+- `analysis_options.yaml` - Excludes generated files (`*.g.dart`, `*.freezed.dart`)
+- Location: `C:\Users\User\Documents\Projects\GNUS\GeniusWallet\analysis_options.yaml`
+
+## Build System
+
+**Desktop (Windows):**
+- CMake 3.18+ - Windows native build orchestration
+  - Location: `windows/CMakeLists.txt`
+  - Supports Debug, Profile, Release configurations
+  - MSVC runtime configuration
+  - Multi-config generator support
+
+**Build Tools:**
+- build_runner 2.4.9 - Code generation and watch mode
+- flutter build (Flutter SDK commands)
+
+## Platform Targets
+
+**Development:**
+- Windows (primary desktop development target)
+- macOS (supported)
+- Linux x86_64 & aarch64 (supported)
+
+**Runtime Deployment:**
+- Windows - Native exe via CMake
+- macOS - .pkg installer
+- Linux x86_64 - x86 builds (tested on Ubuntu 22+)
+- Linux aarch64 - ARM64 builds (tested on Debian Bullseye, Ubuntu 22+)
+- iOS - App distribution via TestFlight
+- Android - APK releases
+- Web - Web platform supported
+
+## Configuration
+
+**Environment:**
+- Flutter channel: `stable`
+- SDK constraint: `"^3.10.0"` (pubspec.yaml)
+- Min Flutter version: 3.10.0
+
+**Build Configuration Files:**
+- `pubspec.yaml` - Main dependencies and app metadata
+- `packages/genius_api/pubspec.yaml` - FFI package dependencies
+- `packages/local_secure_storage/pubspec.yaml` - Secure storage wrapper
+- `windows/CMakeLists.txt` - Windows native build config
+- `analysis_options.yaml` - Linting and analyzer configuration
+- `.metadata` - Flutter project metadata and platform tracking
+
+**Asset Configuration:**
+- `assets/json/networks/networks.json` - Network/blockchain configuration
+- `assets/json/networks/bridge.json` - Bridge configuration
+- `assets/json/tokens/` - Token definitions
+- `assets/network_config.json` - P2P/IPFS bootstrap nodes
+- `assets/log_config.json` - Logging configuration
+- `assets/dev_config.json` - Development configuration
+- `assets/crdt_config.json` - CRDT (Conflict-free Replicated Data Type) config
+- `assets/sgns_config.json` - SGNUS (Genius SDK) configuration
+
+**Font Configuration:**
+- Custom font: JetBrainsMono (Regular, Italic, Bold, ExtraBold variants)
+  - Location: `assets/fonts/JetBrainsMono-*.ttf`
+
+---
+
+*Stack analysis: 2026-07-15*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,421 @@
+<!-- refreshed: 2026-07-15 -->
+# Codebase Structure
+
+**Analysis Date:** 2026-07-15
+
+## Directory Layout
+
+```
+GeniusWallet/
+├── lib/                                 # Main Flutter app code
+│   ├── main.dart                        # App entry point, Sentry init, providers
+│   ├── account/                         # SDK account management UI
+│   │   ├── account_dropdown_selector.dart
+│   │   └── sdk_account_manager.dart
+│   ├── assets/                          # Asset loading utilities
+│   │   └── read_asset.dart             # Load JSON from assets/
+│   ├── banxa/                           # Banxa fiat buy integration
+│   │   ├── banxa_model.dart            # Order, Payment models
+│   │   ├── banxa_api_services.dart     # API client wrapper
+│   │   ├── banxa_order/
+│   │   │   ├── banxa_order_cubit.dart
+│   │   │   ├── banxa_order_state.dart
+│   │   │   ├── create_order_cubit.dart
+│   │   │   └── polling_order_cubit.dart
+│   │   ├── banxa_components/           # Banxa-specific UI widgets
+│   │   ├── banxa_helpers/              # OrderService, DeepLinkService
+│   │   ├── user_kyc/                   # KYC registration
+│   │   ├── banxa_orders_history.dart   # Order list screen
+│   │   ├── banxa_payment.dart          # WebView checkout
+│   │   └── checkout_qr.dart            # QR code display
+│   ├── bloc/                            # App-wide state
+│   │   ├── app_bloc.dart               # Main BLoC (SDK, wallets, SGNUS)
+│   │   ├── app_event.dart              # Events
+│   │   └── app_state.dart              # State + AppStatus enum
+│   ├── chart/                           # Chart components
+│   │   └── crypto_live_chart.dart      # FL Chart integration
+│   ├── components/                      # Shared UI components
+│   │   ├── animation/                  # Animations (fade, slide)
+│   │   ├── bottom_drawer/              # Slide-up drawer
+│   │   ├── button/                     # Button variants (CTA, secondary)
+│   │   ├── coins/                      # Coin/token list widget
+│   │   ├── custom/                     # Custom builders (FutureBuilder)
+│   │   ├── job/                        # Job submission UI
+│   │   ├── overlay/
+│   │   │   ├── responsive_overlay.dart # MobileOverlay, DesktopOverlay
+│   │   │   └── (internal layout helpers)
+│   │   ├── qr/                         # QR code generator
+│   │   ├── scaffold/                   # Custom scaffold/appbar
+│   │   ├── sgnus/                      # SGNUS token components
+│   │   ├── toast/                      # Toast notifications
+│   │   ├── loading.dart                # Loading spinner
+│   │   ├── wallet_overview.dart        # Balance display
+│   │   └── (other UI primitives)
+│   ├── dashboard/                       # Dashboard & related screens
+│   │   ├── home/
+│   │   │   └── view/dashboard_screen.dart # Main dashboard
+│   │   ├── bridge/
+│   │   │   └── bridge_screen.dart      # Token bridge interface
+│   │   ├── chart/
+│   │   │   ├── markets_screen.dart     # CoinGecko market data
+│   │   │   └── dashboard_markets.dart  # Market charts
+│   │   ├── gnus/
+│   │   │   └── cubit/gnus_cubit.dart   # GNUS token logic
+│   │   ├── news/
+│   │   │   └── view/crypto_news_screen.dart # Crypto news feed
+│   │   ├── transactions/
+│   │   │   ├── cubit/transactions_cubit.dart
+│   │   │   ├── transactions_screen.dart
+│   │   │   └── (tx list, filters, details)
+│   ├── hive/                            # Local persistence
+│   │   ├── init.dart                   # Hive box initialization
+│   │   ├── constants/cache.dart        # Box names, keys
+│   │   ├── models/
+│   │   │   ├── coin_gecko_coin.dart
+│   │   │   ├── coin_gecko_market_data.dart
+│   │   │   ├── historical_price_cache_entry.dart
+│   │   │   └── news_article.dart
+│   │   └── services/
+│   │       └── transaction_storage_service.dart
+│   ├── logs/
+│   │   └── submit_logs_screen.dart     # Logs submission for debugging
+│   ├── navigation/
+│   │   ├── router.dart                 # GoRouter definition, routes
+│   │   └── web_view_extras.dart        # Web view configuration
+│   ├── network/
+│   │   └── network_page.dart           # Network status/selection
+│   ├── onboarding/                      # Wallet creation & import flow
+│   │   ├── bloc/new_pin_cubit.dart     # PIN setup
+│   │   ├── new_wallet/
+│   │   │   ├── bloc/new_wallet_bloc.dart
+│   │   │   ├── view/
+│   │   │   │   ├── backup_phrase_screen.dart
+│   │   │   │   ├── recovery_phrase_screen.dart
+│   │   │   │   └── verify_recovery_phrase_screen.dart
+│   │   │   └── routes/new_wallet_flow.dart
+│   │   ├── existing_wallet/
+│   │   │   ├── bloc/existing_wallet_bloc.dart
+│   │   │   ├── view/
+│   │   │   │   ├── select_wallet_type_screen.dart
+│   │   │   │   └── import_security_screen.dart
+│   │   │   └── routes/existing_wallet_flow.dart
+│   │   ├── view/wallet_creation_screen.dart # Entry screen
+│   │   ├── routes/wallet_routes.dart       # Route definitions
+│   │   └── widgets/                        # Reusable onboarding components
+│   ├── providers/                       # App-wide data providers
+│   │   ├── network_provider.dart       # ChangeNotifier (networks)
+│   │   └── network_tokens_provider.dart # ChangeNotifier (tokens per network)
+│   ├── reown/                           # WalletConnect integration
+│   │   ├── reown_connect_button.dart   # Connect button
+│   │   └── test/                        # Test utilities
+│   ├── screens/                         # Top-level screens
+│   │   ├── splash.dart                 # Splash screen
+│   │   ├── loading_screen.dart         # Loading state
+│   │   ├── pin_screen.dart             # PIN entry
+│   │   ├── banxa_buy_screen.dart       # Banxa form
+│   │   └── order_details_page.dart     # Order status display
+│   ├── services/                        # External API clients
+│   │   ├── coin_gecko/
+│   │   │   └── coin_gecko_api.dart     # Market data fetching
+│   │   ├── coin_telegraph/             # News aggregator
+│   │   └── coins_service.dart          # Coin utility methods
+│   ├── settings/
+│   │   └── settings_screen.dart        # App settings UI
+│   ├── squid_router/                    # Squid Protocol swaps
+│   │   ├── swap_screen.dart            # Swap interface
+│   │   ├── models/                     # Swap data models
+│   │   └── (swap logic)
+│   ├── submit_job/                      # Job submission (SGNUS compute)
+│   │   ├── cubit/submit_job_cubit.dart
+│   │   └── view/submit_job_screen.dart
+│   ├── test/                            # Dev utilities
+│   │   ├── dev_overrides.dart          # Mock data (test mode)
+│   │   └── dev_tools_widget.dart       # Debug panel
+│   ├── theme/                           # Design system
+│   │   ├── theme.dart                  # MaterialTheme definition
+│   │   ├── genius_wallet_colors.dart   # Color palette
+│   │   ├── genius_wallet_consts.dart   # Padding, sizes, durations
+│   │   └── genius_wallet_gradient.dart # Gradient definitions
+│   ├── tokens/                          # Token info screen
+│   │   └── token_info_screen.dart
+│   ├── tokeninfo/                       # Token information
+│   │   └── (token detail views)
+│   ├── utils/                           # Utility functions
+│   │   ├── breakpoints.dart            # Responsive layout helpers
+│   │   ├── formatters.dart             # Number, date formatting
+│   │   ├── image_utils.dart            # Image loading helpers
+│   │   └── wallet_utils.dart           # Wallet address helpers
+│   ├── wallets/                         # Wallet management
+│   │   └── cubit/
+│   │       ├── wallet_details_cubit.dart
+│   │       └── wallet_details_state.dart
+│   └── web/                             # Web-specific features
+│       ├── web_view_screen.dart        # In-app browser
+│       ├── windows_webview_shutdown.dart # Cleanup on exit
+│       └── (platform-specific web logic)
+│
+├── packages/                            # Local path dependencies
+│   ├── genius_api/                      # Core API abstraction (monorepo)
+│   │   ├── lib/
+│   │   │   ├── genius_api.dart         # Public exports
+│   │   │   ├── src/genius_api.dart     # Main GeniusApi class
+│   │   │   ├── ffi/
+│   │   │   │   ├── genius_api_ffi.dart # FFI bindings to GeniusSDK
+│   │   │   │   └── trust_wallet_api_ffi.dart # Trust Wallet FFI
+│   │   │   ├── models/
+│   │   │   │   ├── wallet.dart
+│   │   │   │   ├── coin.dart
+│   │   │   │   ├── network.dart
+│   │   │   │   ├── account.dart
+│   │   │   │   ├── sgnus_connection.dart
+│   │   │   │   └── models.dart (exports)
+│   │   │   ├── controllers/
+│   │   │   │   ├── sgnus_connection_controller.dart
+│   │   │   │   └── sgnus_transactions_controller.dart
+│   │   │   ├── web3/
+│   │   │   │   ├── web3.dart           # web3dart wrapper
+│   │   │   │   └── api_response.dart   # Response modeling
+│   │   │   ├── types/
+│   │   │   │   ├── wallet_type.dart
+│   │   │   │   ├── security_type.dart
+│   │   │   │   └── (other enums/types)
+│   │   │   ├── extensions/             # Dart extensions
+│   │   │   ├── proto/                  # Protobuf-generated files
+│   │   │   │   └── SGTransaction.pb.dart
+│   │   │   ├── tw/                     # Trust Wallet FFI utilities
+│   │   │   │   ├── hd_wallet.dart
+│   │   │   │   ├── stored_key.dart
+│   │   │   │   ├── any_address.dart
+│   │   │   │   └── coin_util.dart
+│   │   │   ├── ffi_bridge_prebuilt.dart # Binary coordination
+│   │   │   ├── test/dev_overrides.dart # Test data
+│   │   │   └── (other utilities)
+│   │   ├── pubspec.yaml
+│   │   └── (other package files)
+│   │
+│   └── local_secure_storage/            # Secure key-value storage (monorepo)
+│       ├── lib/
+│       │   ├── local_secure_storage.dart # Public exports
+│       │   ├── src/
+│       │   │   └── local_secure_storage.dart # Main class
+│       │   └── (platform implementations)
+│       └── pubspec.yaml
+│
+├── assets/                              # Static assets
+│   ├── fonts/                           # Custom fonts
+│   ├── images/                          # PNG, SVG images
+│   │   └── crypto/                      # Cryptocurrency icons
+│   └── json/
+│       ├── networks/                    # Network configuration JSON
+│       └── tokens/                      # Token list JSON
+│
+├── android/                             # Android platform code
+│   ├── app/
+│   │   └── src/
+│   │       ├── debug/
+│   │       ├── main/
+│   │       │   ├── kotlin/ (or java/)   # Kotlin/Java platform glue
+│   │       │   └── AndroidManifest.xml
+│   │       └── profile/
+│   └── build.gradle
+│
+├── ios/                                 # iOS platform code
+│   ├── Runner/
+│   │   ├── Info.plist
+│   │   ├── GeneratedPluginRegistrant.swift
+│   │   └── (other iOS files)
+│   ├── native/                          # Custom iOS code
+│   └── Runner.xcodeproj/
+│
+├── windows/                             # Windows platform code
+│   ├── runner/
+│   │   └── (Windows C++ entry)
+│   └── (Windows project files)
+│
+├── macos/                               # macOS platform code
+│   └── (macOS project files)
+│
+├── web/                                 # Web platform code
+│   ├── index.html
+│   └── (web assets)
+│
+├── linux/                               # Linux platform code
+│   └── (Linux build files)
+│
+├── test/                                # Flutter unit/widget tests
+│   └── (test files)
+│
+├── pubspec.yaml                         # Main project dependencies
+├── pubspec.lock                         # Lockfile
+├── analysis_options.yaml                # Dart linter config
+├── CLAUDE.md                            # Project instructions
+├── .sentry-native/                      # Sentry native SDK (generated)
+└── (other root files: .gitignore, README, etc.)
+```
+
+## Directory Purposes
+
+**lib/** - All Dart/Flutter source code (main app)
+
+**lib/bloc/** - App-wide state management (AppBloc) coordinating SDK init, wallets, SGNUS stream
+
+**lib/banxa/** - Fiat on-ramp feature (Banxa API integration, order lifecycle, KYC)
+
+**lib/components/** - Shared, reusable UI widgets (buttons, overlays, QR, toast)
+
+**lib/dashboard/** - Home screen and related modules (markets, news, transactions, bridges)
+
+**lib/hive/** - Local NoSQL persistence (Hive models, box initialization, cache keys)
+
+**lib/navigation/** - Navigation routing with GoRouter, deep link handling, route guards
+
+**lib/onboarding/** - Wallet creation & import flows (new wallet, existing wallet import)
+
+**lib/providers/** - App-wide data providers (ChangeNotifier) for networks and tokens
+
+**lib/services/** - External API integrations (CoinGecko, Banxa, news, coin utilities)
+
+**lib/squid_router/** - Token swap interface (Squid Protocol integration)
+
+**lib/theme/** - Design system (colors, gradients, sizes, responsive breakpoints)
+
+**lib/utils/** - Utility functions (formatters, image utils, wallet helpers)
+
+**lib/wallets/** - Wallet selection & details state management (WalletDetailsCubit)
+
+**packages/genius_api/** - Local path package: GeniusApi facade, FFI bindings, models, controllers
+
+**packages/local_secure_storage/** - Local path package: secure wallet key storage (platform-specific)
+
+**assets/json/** - Network and token metadata (loaded by providers)
+
+**android/, ios/, windows/, macos/, linux/, web/** - Platform-specific code and build configs
+
+## Key File Locations
+
+**Entry Points:**
+- `lib/main.dart` - App bootstrap, Sentry init, provider setup
+- `lib/navigation/router.dart` - All route definitions via GoRouter
+- `lib/onboarding/routes/wallet_routes.dart` - Onboarding subroutes
+
+**Configuration:**
+- `pubspec.yaml` - Dependencies, assets
+- `analysis_options.yaml` - Dart lint rules
+- `lib/theme/` - Design tokens
+- `assets/json/networks/`, `assets/json/tokens/` - Blockchain metadata
+
+**Core Logic:**
+- `packages/genius_api/lib/src/genius_api.dart` - Main API facade
+- `lib/bloc/app_bloc.dart` - App state orchestration
+- `lib/hive/init.dart` - Database initialization
+- `lib/providers/` - Global data loaders
+
+**Testing & Dev:**
+- `lib/test/dev_overrides.dart` - Mock wallet data
+- `lib/test/dev_tools_widget.dart` - Debug panel (kDebugMode only)
+- `test/` - Unit/widget test files
+
+## Naming Conventions
+
+**Files:**
+- `*_screen.dart` - Full-page view (StatelessWidget or StatefulWidget)
+- `*_cubit.dart` - Cubit state manager (single method, copyWith state)
+- `*_bloc.dart` - BLoC state manager (multiple events)
+- `*_state.dart` - State class (partner to cubit/bloc)
+- `*_model.dart` - Data model (Equatable or freezed)
+- `*_provider.dart` - ChangeNotifier provider
+- `*_widget.dart` - Reusable component (not a full screen)
+- `*_controller.dart` - Stream/service controller (RxDart, StreamController)
+- `*_service.dart` or `*_client.dart` - External API wrapper
+- `*_helper.dart` or `*_util.dart` - Utility functions
+
+**Directories:**
+- `*/view/` - View layer (screens, layouts)
+- `*/cubit/` or `*/bloc/` - State management
+- `*/routes/` - Navigation routes and flows
+- `*/models/` - Data models
+- `*/widgets/` - Reusable UI components
+- `*/services/` or `*/api/` - External integrations
+
+**Dart Classes:**
+- `CamelCase` for class names (ScreenName, CubitName, Widget)
+- `camelCase` for functions and variables
+- `UPPER_SNAKE_CASE` for constants (but rarely used; prefer static const)
+- Avoid single-letter names except loop iterators
+
+**Routes (GoRouter):**
+- `/` - Splash
+- `/dashboard`, `/transactions`, `/swap`, `/markets`, `/news`, `/web`, `/logs`, `/settings` - Main shell routes
+- `/landing_screen`, `/backup_phrase`, `/recovery_phrase`, `/verify_recovery_phrase`, `/import_wallet`, `/import_existing_wallet`, `/create_wallet` - Onboarding routes
+- `/buy`, `/createOrder`, `/orderDetails`, `/checkout`, `/checkoutQR`, `/kyc`, `/banxa/callback` - Banxa routes
+- `/token-info`, `/bridge`, `/submit_job`, `/network` - Feature routes
+
+## Where to Add New Code
+
+**New Feature (e.g., Staking):**
+- Primary code: `lib/staking/` (mirror structure: cubit, view, models, routes)
+- Cubit: `lib/staking/cubit/staking_cubit.dart`, `staking_state.dart`
+- Screens: `lib/staking/view/staking_screen.dart`, `staking_details_screen.dart`
+- Routes: `lib/staking/routes/staking_routes.dart`, add to `lib/navigation/router.dart`
+- Models: `lib/staking/models/stake.dart`, `reward.dart`
+- State: Add to AppBloc or create top-level cubit injected in router
+
+**New Component/Widget:**
+- Implementation: `lib/components/{category}/` (e.g., `lib/components/card/stake_card.dart`)
+- Reusable? → `lib/components/`; Feature-specific? → `lib/{feature}/widgets/`
+- Always use StatelessWidget unless state needed; prefer Cubit for logic
+
+**Utilities:**
+- Shared helpers: `lib/utils/{category}.dart` (e.g., `utils/date_format.dart`)
+- Feature-specific helpers: `lib/{feature}/helpers/` or `lib/{feature}/{category}_helper.dart`
+
+**Service/API Client:**
+- External integrations: `lib/services/{service_name}/` (e.g., `lib/services/coingecko/`)
+- API wrapper: `lib/services/{service_name}/{service_name}_api.dart` or `{service_name}_client.dart`
+- Models: `lib/services/{service_name}/models/`
+
+**Database Model:**
+- Hive models: `lib/hive/models/{entity}.dart` (use @HiveType annotation)
+- Register in `lib/hive/init.dart` before Hive.openBox()
+- Reference in cache.dart constants
+
+**BLoC/Cubit:**
+- Feature cubit: `lib/{feature}/cubit/{feature}_cubit.dart`
+- App-wide bloc: `lib/bloc/app_bloc.dart` (only this one, no others at top level)
+- Always split event/state into separate part files or imports
+
+**Test:**
+- Widget tests: `test/{feature}_test.dart` or `test/{feature}/screen_test.dart`
+- Mock dependencies via package:mockito
+- Run: `flutter test`
+
+## Special Directories
+
+**lib/test/ (not test/):**
+- Purpose: Dev-mode overrides and debug tools
+- Generated: No (manually maintained)
+- Committed: Yes (controlled via kDebugMode conditionals)
+
+**lib/hive/:**
+- Purpose: Hive box definitions and schemas
+- Generated: models.g.dart (auto-generated by hive_generator, run `flutter pub run build_runner build`)
+- Committed: models.dart and init.dart; excluded: *.g.dart (or committed, varies by project)
+
+**packages/**
+- Purpose: Local monorepo packages (shared libraries)
+- Generated: No
+- Committed: Yes (part of source tree)
+
+**assets/json/:**
+- Purpose: Blockchain and token metadata (networks, tokens)
+- Generated: No (manually maintained or fetched externally)
+- Committed: Yes
+
+**build/, .dart_tool/, pubspec.lock:**
+- Purpose: Build artifacts and dependency cache
+- Generated: Yes
+- Committed: pubspec.lock only (not build/ or .dart_tool/)
+
+---
+
+*Structure analysis: 2026-07-15*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,335 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-07-15
+
+## Test Framework
+
+**Runner:**
+- Framework: `flutter_test` (built into Flutter SDK)
+- Config: No dedicated config file (`flutter_test` uses defaults)
+- Location: Test files in `test/` directory at repo root
+
+**Assertion Library:**
+- Built-in Flutter test assertions: `expect()`, matchers like `isNotNull`, `equals()`, `greaterThan()`
+- No custom assertion library
+
+**Run Commands:**
+```bash
+flutter test                 # Run all tests
+flutter test --watch        # Watch mode
+flutter test --coverage     # Generate coverage report
+flutter test test/filename_test.dart  # Run specific test file
+```
+
+**Dependencies:**
+- `flutter_test` (SDK) - Test framework
+- `mockito` ^5.0.0 - Mocking library
+- `http` ^1.2.2 - HTTP client (also provides `http/testing` for MockClient)
+- **Note:** No `bloc_test` or `mocktail` in dependencies; raw mocking used
+
+## Test File Organization
+
+**Location:**
+- Root: `test/` directory at repo root
+- Pattern: `test/[filename]_test.dart`
+
+**Active Test Files:**
+- `test/token_info_loader_test.dart` (217 lines, fully functional)
+- `test/local_wallet_storage_test.dart` (241 lines, entirely commented out)
+- `test/CMakeLists.txt` (build config)
+
+**Test Coverage Reality:**
+- **Minimal test harness:** Only 1 actively running test file
+- **No Bloc/Cubit tests:** Despite heavy BLoC usage (`lib/bloc/`, `lib/[feature]/cubit/`), no corresponding tests
+- **No widget tests:** No tests for Flutter widget rendering
+- **No integration tests:** E2E flow not tested
+- **No API tests:** HTTP/external service integration tested only manually or not at all
+
+## Test Structure
+
+**Suite Organization:**
+
+```dart
+void main() {
+  group('TokenInfoLoader', () {
+    late TokenInfoLoader tokenLoader;
+
+    setUp(() {
+      tokenLoader = TokenInfoLoader();
+    });
+
+    tearDown(() {
+      tokenLoader.dispose();
+    });
+
+    test('loads single token from GitHub (first in array)', () async {
+      final token = await tokenLoader.loadToken();
+      
+      expect(token, isNotNull);
+      expect(token!.name, equals('GNUS'));
+    });
+
+    group('error handling', () {
+      test('handles network errors gracefully', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response('Not Found', 404);
+        });
+
+        final loader = TokenInfoLoader(httpClient: mockClient);
+        final token = await loader.loadToken();
+        
+        expect(token, isNull);
+      });
+    });
+  });
+}
+```
+
+**Patterns:**
+- `group()`: Organize tests by feature/concern
+- `setUp()`: Initialize fixtures (runs before each test)
+- `tearDown()`: Cleanup (runs after each test)
+- `test()`: Individual test case
+- `expect()`: Assert expected behavior
+- `late`: Lazy initialization for test doubles
+
+## Mocking
+
+**Framework:** 
+- `mockito` ^5.0.0
+- No configuration file (uses defaults)
+
+**HTTP Mocking Pattern:**
+```dart
+import 'package:http/testing.dart' as http;
+
+final mockClient = MockClient((request) async {
+  if (request.url.toString().contains('github')) {
+    return http.Response('''
+      [
+        {
+          "id": "000...",
+          "name": "GNUS",
+          "iconUrl": "https://example.com/gnus.png"
+        }
+      ]
+    ''', 200);
+  }
+  return http.Response('Not Found', 404);
+});
+
+final loader = TokenInfoLoader(httpClient: mockClient);
+final tokens = await loader.loadTokens();
+expect(tokens.length, equals(1));
+```
+
+**Mockito Annotation-Based Mocks (Commented Out):**
+From `test/local_wallet_storage_test.dart`:
+```dart
+// @GenerateMocks([Web3])
+// @GenerateMocks([MockFlutterSecureStorage])
+// void main() {
+//   late MockWeb3 mockWeb3;
+//   late MockFlutterSecureStorage mockSecureStorage;
+//   
+//   when(mockSecureStorage.read(key: '__pin_key__'))
+//       .thenAnswer((_) async => '1234');
+// }
+```
+
+**What to Mock:**
+- HTTP clients (external APIs): Wrap client in service, inject mock
+- Secure storage for PIN/key tests
+- FFI bindings for SDK initialization (not currently tested)
+
+**What NOT to Mock:**
+- Core business logic (use real implementations)
+- Model serialization (freezed/Hive generation)
+- BLoC state transitions (test against real BLoC)
+
+## Fixtures and Factories
+
+**Test Data:**
+```dart
+test('caching prevents unnecessary network calls', () async {
+  var callCount = 0;
+  final mockClient = MockClient((request) async {
+    callCount++;
+    return http.Response('''
+      [
+        {
+          "id": "0000000000000000000000000000000000000000000000000000000000000000",
+          "name": "GNUS",
+          "iconUrl": "https://example.com/icon.png"
+        }
+      ]
+    ''', 200);
+  });
+
+  final loader = TokenInfoLoader(httpClient: mockClient);
+  
+  final tokens1 = await loader.loadTokensWithCache();
+  expect(callCount, equals(1));
+  
+  final tokens2 = await loader.loadTokensWithCache(
+    cachedTokens: tokens1,
+    lastFetch: DateTime.now(),
+    cacheDuration: const Duration(hours: 1),
+  );
+  expect(callCount, equals(1)); // Cached
+});
+```
+
+**Location:** Fixtures defined inline in test functions; no shared factory directory.
+
+**Pattern:** Hardcoded JSON strings for HTTP mocks; parameterized test data where needed.
+
+## Coverage
+
+**Requirements:** None enforced (no coverage config in `pubspec.yaml` or CI)
+
+**View Coverage:**
+```bash
+flutter test --coverage           # Generate coverage/.lcov.info
+# View in IDE or upload to codecov (not currently done)
+```
+
+**Current State:** Coverage is unmeasured; existing test harness is too minimal to be meaningful.
+
+## Test Types
+
+**Unit Tests:**
+- Scope: Single function/class in isolation (e.g., `TokenInfoLoader.loadToken()`)
+- Approach: Mock HTTP client, verify return value and caching behavior
+- Example: `test/token_info_loader_test.dart` (8 tests, HTTP layer only)
+
+**Integration Tests:**
+- Scope: None implemented
+- Would cover: BLoC → Service → API flow
+- Gap: Entire app state management is untested
+
+**Widget Tests:**
+- Scope: None implemented
+- Would cover: UI rendering, user interactions
+- Gap: No tests for UI components or navigation
+
+**E2E Tests:**
+- Framework: Not used
+- Would cover: Full app flows from onboarding to transaction
+- Gap: Manual testing only
+
+## Common Patterns
+
+**Async Testing:**
+```dart
+test('loads single token from GitHub (first in array)', () async {
+  final token = await tokenLoader.loadToken();
+  
+  expect(token, isNotNull);
+  expect(token!.name, equals('GNUS'));
+});
+```
+- `async` keyword on test function
+- `await` for async operations
+- `late` for fixture initialization
+
+**Error Testing:**
+```dart
+test('handles network errors gracefully', () async {
+  final mockClient = MockClient((request) async {
+    return http.Response('Not Found', 404);
+  });
+
+  final loader = TokenInfoLoader(httpClient: mockClient);
+  final token = await loader.loadToken();
+  
+  expect(token, isNull);  // Returns null on error
+});
+
+test('handles invalid JSON gracefully', () async {
+  final mockClient = MockClient((request) async {
+    return http.Response('Invalid JSON', 200);
+  });
+
+  final loader = TokenInfoLoader(httpClient: mockClient);
+  final token = await loader.loadToken();
+  
+  expect(token, isNull);
+});
+```
+
+## Test Execution
+
+**Can tests actually compile and run?**
+
+Yes. Test harness works:
+```bash
+$ flutter test
+# Output: 16 tests in token_info_loader_test.dart pass
+# Tests that actually run against real GitHub API (lines 191-214)
+```
+
+**Compilation:** 
+- Tests compile successfully when enabled
+- Commented tests in `local_wallet_storage_test.dart` are syntactically valid (verified by past execution)
+
+**Integration with CI:**
+- No CI config detected (no `.github/workflows/`, `.gitlab-ci.yml`, etc.)
+- Tests not run on commit or PR
+
+## Testing Critical Paths
+
+**Gap Analysis:**
+
+| Area | Status | Impact |
+|------|--------|--------|
+| BLoC state management | Untested | High - core app logic |
+| Cubit (PIN verification, wallet creation) | Untested | High - user flows |
+| Wallet/transaction service | Untested | High - money-critical |
+| Router/navigation | Untested | Medium - UX |
+| Network requests | Partial - only `TokenInfoLoader` tested | Medium |
+| Error handling | Untested | High - crash recovery |
+| FFI bindings to SDK | Untested | Critical - SDK stability |
+| UI components | Untested | Low - visual inspection |
+
+## Recommended Testing Practices
+
+**Unit Testing Pattern (if adding tests):**
+```dart
+void main() {
+  group('PinCubit', () {
+    late PinCubit pinCubit;
+    late MockGeniusApi mockApi;
+
+    setUp(() {
+      mockApi = MockGeniusApi();
+      pinCubit = PinCubit(pinMaxLength: 4, geniusApi: mockApi);
+    });
+
+    tearDown(() async {
+      await pinCubit.close();
+    });
+
+    test('emits PinFullness.completed when PIN reaches max length', () {
+      pinCubit.add('1');
+      pinCubit.add('2');
+      pinCubit.add('3');
+      pinCubit.add('4');
+
+      expect(pinCubit.state.pinFullness, equals(PinFullness.completed));
+    });
+
+    test('verifyPin emits success on correct PIN', () async {
+      when(mockApi.verifyUserPin('1234')).thenAnswer((_) async => true);
+
+      await pinCubit.verifyPin();
+
+      expect(pinCubit.state.verificationStatus, equals(VerificationStatus.pass));
+    });
+  });
+}
+```
+
+---
+
+*Testing analysis: 2026-07-15*

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,90 @@
+{
+  "model_profile": "adaptive",
+  "commit_docs": true,
+  "parallelization": true,
+  "search_gitignored": false,
+  "brave_search": false,
+  "firecrawl": false,
+  "exa_search": false,
+  "tavily_search": false,
+  "ref_search": false,
+  "perplexity": false,
+  "jina": false,
+  "git": {
+    "branching_strategy": "none",
+    "create_tag": true,
+    "phase_branch_template": "gsd/phase-{phase}-{slug}",
+    "milestone_branch_template": "gsd/{milestone}-{slug}",
+    "quick_branch_template": null
+  },
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true,
+    "nyquist_validation": true,
+    "auto_advance": false,
+    "node_repair": true,
+    "node_repair_budget": 2,
+    "ui_phase": true,
+    "ui_safety_gate": true,
+    "ai_integration_phase": true,
+    "human_verify_mode": "end-of-phase",
+    "context_guard_mode": "warn",
+    "text_mode": false,
+    "research_before_questions": false,
+    "discuss_mode": "discuss",
+    "skip_discuss": false,
+    "code_review": true,
+    "code_review_depth": "standard",
+    "code_review_command": null,
+    "pattern_mapper": true,
+    "plan_bounce": false,
+    "plan_bounce_script": null,
+    "plan_bounce_passes": 2,
+    "auto_prune_state": false,
+    "post_planning_gaps": true,
+    "security_enforcement": true,
+    "security_asvs_level": 1,
+    "security_block_on": "high"
+  },
+  "ship": {
+    "pr_body_sections": [
+      {
+        "heading": "User Stories & Acceptance Criteria",
+        "enabled": false,
+        "source": "REQUIREMENTS.md ## User Stories || REQUIREMENTS.md ## Acceptance Criteria",
+        "fallback": "- Acceptance criteria are covered by the linked requirements and verification evidence."
+      },
+      {
+        "heading": "Risks & Dependencies",
+        "enabled": false,
+        "source": "PLAN.md ## Risks || PLAN.md ## Dependencies",
+        "fallback": "- No known high-risk rollout dependencies."
+      },
+      {
+        "heading": "Success Metrics & Release Criteria",
+        "enabled": false,
+        "source": "REQUIREMENTS.md ## Definition of Done || VERIFICATION.md ## Release Criteria",
+        "fallback": "- Release when automated verification and required manual checks pass."
+      },
+      {
+        "heading": "Stakeholder Review & Approval",
+        "enabled": false,
+        "template": "- Product owner approval pending for {phase_name}."
+      }
+    ]
+  },
+  "hooks": {
+    "context_warnings": true
+  },
+  "project_code": null,
+  "phase_naming": "sequential",
+  "agent_skills": {},
+  "claude_md_path": "./.claude/CLAUDE.md",
+  "plan_review": {
+    "source_grounding": true,
+    "source_grounding_authority": "grep"
+  },
+  "mode": "interactive",
+  "granularity": "standard"
+}


### PR DESCRIPTION
## What

Adopts the **GSD** planning workflow for GeniusWallet by adding the `.planning/` infrastructure. This is **infra only** — no application code changes. Isolated on its own branch so it stays out of the UI-redesign PR.

## Contents

- **Codebase map** (`.planning/codebase/`, 7 docs) — brownfield analysis produced by parallel mapper agents: `ARCHITECTURE`, `STRUCTURE`, `STACK`, `INTEGRATIONS`, `CONVENTIONS`, `TESTING`, `CONCERNS`.
- **`PROJECT.md`** — project context; Validated requirements inferred from the codebase map.
- **`config.json`** — workflow config: `mode=interactive`, `granularity=standard`, `model_profile=adaptive`, research/plan-check/verifier on, `commit_docs=true`.
- **`REQUIREMENTS.md` / `ROADMAP.md` / `STATE.md`** — a thin, honest first milestone scoped to completing the UI-redesign forward-port (Adopt GSD → Forward-port fidelity → Visual/UAT hardening → Merge to develop).

## Why interactive mode

`.planning/` is committed to the shared repo, so the config is team-visible. Interactive mode keeps GSD approval-gated rather than auto-executing on shared code.

## Notes

- Zero runtime/source changes — safe to merge independently of the redesign work.
- `gsd-tools` roadmap validation passes with no warnings; secret-scan of generated docs is clean.
- Once merged to `develop`, GSD commands (e.g. `gsd-quick`, `gsd-plan-phase`) become available on branches based off `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)