### PR TITLE
Charts closed out, coin page off sketch 164, and one row hover for every list

### DIFF
--- a/.planning/HANDOFF-260730-charts-coin-page-and-row-hover.md
+++ b/.planning/HANDOFF-260730-charts-coin-page-and-row-hover.md
@@ -1,0 +1,151 @@
+# Handoff · 2026-07-30 · Charts closed out, coin page reworked, row hover unified
+
+**Branch:** `redesign/jakub-260728`, fast-forwarded to `origin/ui-redesign-port` at `dce14b92`
+before any work started - it carried **zero** commits of its own, so this branch is Braian's
+Phase 23 work plus this session on top. **PR opens against `ui-redesign-port`, never `main`.**
+
+**Gates, measured at the end of the session, not quoted:**
+
+| Gate | Result |
+|---|---|
+| `flutter analyze` | **1 issue**, and it is `test/account/account_drawer_show_test.dart` - untracked, local-only, see below |
+| `tool/check_brace_style.sh --count` | **0** |
+| `tool/check_raw_colors.sh --count` | **0** |
+| `dart format --set-exit-if-changed lib` | **exit 0** |
+| `flutter test` (all dirs except `test/account/`) | **688 pass / 0 fail** |
+
+`test/account/account_drawer_show_test.dart` is still deliberately absent from git. It hangs the
+suite (`testWidgets` + a real Hive box), which is why every test run here excludes `test/account/`.
+Do not add it.
+
+---
+
+## 1 · What shipped
+
+### Charts - the topic resumed from `HANDOFF-260729-compute-charts-and-header.md`
+
+- **Coin-page chart header reaches the right edge.** The timeframe segment sat short of it with a
+  band of dead space beyond. Cause: a loose `Flexible` for the price plus a `Spacer`, both at the
+  default `flex: 1`, splitting free space 50/50; the price does not spend its half and `RenderFlex`
+  parks the remainder AFTER the last child. **Identical defect to the one `gw_page_header.dart` was
+  fixed for the day before.** Readouts now take one `Expanded`.
+
+- **Markets hero takes the trading frame at 253px.** See §2 - the finding is bigger than the change.
+
+### Coin page (sketch 164, Jakub picked A and C)
+
+- **24h-range tile.** Two problems, and the first hypothesis was wrong: the track was NOT
+  collapsing to zero width (measured 189px before any fix). It was painted `surfaceSunken` #06080C
+  on a `surfaceElevated` #0C0E14 card - **1.04:1**, darker than its own background - with a
+  `borderSubtle` edge at 1.36:1. Light mode hid it, because there `surfaceSunken` is a visible grey.
+  Now `borderStrong`, which reads on both canvases. Separately the tile was **77px against its five
+  neighbours' 65px** (`space4` + a 4px bar) because a `Wrap` neither stretches nor equalises; the
+  rail is now chunked `Row`s under `IntrinsicHeight`. That forced the tile's inner `LayoutBuilder`
+  out - it refuses intrinsic queries - so the marker is an `Align` on a fractional x.
+
+- **Read-only Token price is no longer a field.** It is a `GWDetailGrid` row, matching `Total` one
+  line below. The rejected alternative was Jakub's own first instinct - keep the box, grey the value
+  - and it was rejected on a measurement: `textSecondary` on `surfaceSunken` is 6.20:1 dark but
+  **4.23:1 light**, under the 4.5:1 body floor. This variant keeps `textPrimary` and has no such
+  debt. It also removes a wart the old comment admitted: a `readOnly` field still takes focus in
+  Flutter. `_tokenPriceController` went with it (a `double` was being stringified and re-parsed).
+
+- **Receive / Swap / Bridge gained an edge.** `Icons.qr_code_2` became `Icons.call_received`;
+  `swap_horiz` is unchanged, per Jakub. The glyph carries the brand gradient via `ShaderMask` using
+  `brandCtaText`, **not** `brandCta` - the raw stops measure 1.65:1 / 2.28:1 on a light surface;
+  the helper collapses to flat `#0A6885` (6.30:1) there. Dark stops are 10.39:1 and 7.54:1.
+
+### Row hover - one component, five call sites
+
+`GWHoverRow` in `lib/components/effects/gw_hover_row.dart`. Rounded `radiusMd` highlight, click
+cursor, its own transparent `Material`, and an explicit hover colour of `gw.textPrimary` at **6%**
+(`kGWRowHoverAlpha`). 6% is one surface step: **1.135** on `surfaceElevated`, against
+`surfaceMenu`'s 1.108. Flutter's stock `ThemeData.hoverColor` is 4% (1.086) and every row in the app
+was silently inheriting it.
+
+Migrated: `TransactionRow`, `markets_table._dataRow`, `CoinCardRow` (Assets),
+`CryptoSparkLineChart` (dashboard Markets panel), `GWTokenRow`.
+
+---
+
+## 2 · The finding that matters most - a "falsified" hypothesis that was not
+
+`markets_hero_height_test.dart` recorded that growing the hero chart 180 → 253 costs the wide card
+73px, and `kMarketsHeroChartHeight` sat at 180 for that reason. **The test never reached the wide
+layout.** Its host wrapped the card in `SizedBox(width: 1200)` and its comments asserted that width
+"clears `GeniusBreakpoints.medium` (768), so this is the WIDE (`IntrinsicHeight` row) layout" - but
+it never set `tester.view.physicalSize`, which defaults to **800x600**. The `SizedBox` was clamped
+and the card rendered **stacked**. The stacked branch passes `fill: false`: no `Spacer`, no
+`IntrinsicHeight`. So of course it grew by exactly the chart's delta. **619.0 and 692.0 are
+stacked-layout numbers.** It measured the one layout the claim was never about.
+
+Re-measured with the surface actually set to 1400x1000: the `IntrinsicHeight` row reports
+**301.0** - the original derivation to the pixel - and the card holds **367.0** at both 180 and 253,
+verified by flipping the constant and re-running. The arithmetic was right; the instrument was wrong.
+The handoff's "missing 284px is not yet explained" was never a real gap.
+
+**The rule this earns: a widget test that does not set its surface is not testing the width it
+says it is.** Both layouts are now pinned at surfaces that actually produce them, and there is a
+separate assertion that the LEFT column still drives the row - which is the real invariant behind
+the constant, not the card height.
+
+Stacked hero deliberately stays at 180 (`kMarketsHeroChartHeightStacked`): no `Spacer` there, so
+every pixel is real growth, and 180 sits below `kChartFrameMinHeight` so it keeps the axis-free
+chart - the same runtime A/B rule the coin page follows.
+
+---
+
+## 3 · Walked, and NOT walked - do not read this as all-green
+
+| Change | Status |
+|---|---|
+| Range tile, timeframe alignment | **Walked live by Jakub**, dark |
+| Read-only row, action icons, hero frame | **Walked live by Jakub**, dark |
+| Row hover: Transactions, Markets page, Assets | **Walked live by Jakub**, dark |
+| Row hover: **dashboard Markets panel** | **NOT walked.** Fixed after Jakub's last look; hot reload was clean and 688 tests pass, but no human has seen it |
+| **Light mode, all of the above** | **NOT walked at all this session** |
+
+The light-mode gap is the honest risk. Every colour decision above carries a measured light figure,
+but measured is not seen.
+
+---
+
+## 4 · Left deliberately un-fixed - do not "helpfully" fix these
+
+1. **The timeframe segment is still a fake.** `GWTimeframeSegment` has **no `onChanged`** by design
+   (user decision, 2026-07-21, "visual-only"), and the Markets hero carries its own separate copy
+   with 24H/7D/30D/1Y labels. Tapping moves the chip and changes nothing. This was the agreed next
+   task and is the last thing on these charts that lies.
+   `.planning/todos/pending/2026-07-21-wire-real-timeframe-ranges-in-crypto-live-chart.md`
+
+2. **Markets table rows keep a full-width bottom hairline under the rounded highlight.** That rule
+   belongs to the TABLE, not the row; insetting it would stop it separating the columns it exists to
+   separate. Flagged to Jakub, awaiting his eye in motion.
+
+3. **Four tappable list rows were found and deliberately NOT migrated to `GWHoverRow`** - outside
+   the scope Jakub set. Named so the next person does not have to re-sweep:
+   `job_step_list.dart:161` (bare `InkWell`, no radius), `sdk_account_manager.dart:710`,
+   `submit_logs_screen.dart:661`, `bridge_screen.dart:824` (a `ListTile` with the same buried-ink
+   trap as Assets).
+
+4. **Two chart todos are now obsolete and should be closed, not worked:**
+   `2026-07-21-chart-zoom-pan-icons-still-raw-colors-white.md` and
+   `2026-07-21-chart-zoom-pan-row-overflows-34px.md`. Both describe the zoom/pan buttons, which
+   `260729-gt4` deleted.
+
+5. **`.planning/sketches/165-coin-page-schemes/` is NOT in this PR.** It was being written by a
+   parallel session while this one was closing (files stamped 11:51-11:53, after this session's own
+   work). It is on disk, untracked, and belongs to whoever is writing it.
+
+---
+
+## 5 · Environment
+
+- **Hot reload works across turns** via a FIFO on `flutter run`'s stdin - `echo r > $D/gw.fifo`.
+  Never `R`: hot restart kills the app on the native node's RocksDB lock.
+- The app was killed at end of session. A stale instance holds the Hive container lock and makes the
+  next launch a silent black window.
+- The six Apple-signing files remain held out via `skip-worktree`. `git ls-files -v | grep '^S'`
+  confirms all six. **Never `git add -A` in this repo.**
+- The two cmake fixes this project used to carry in the working tree (`TIMEOUT 3600`, Snappy
+  `QUIET`) are now **upstream** - `cmake/` is clean. That note in the older handoffs is stale.

--- a/.planning/sketches/164-readonly-and-action-icons/README.md
+++ b/.planning/sketches/164-readonly-and-action-icons/README.md
@@ -1,0 +1,92 @@
+# Sketch 164 · Read-only field + coin-page action icons
+
+**Design question.** Two controls on the coin page do not say what they are.
+The Convert card's *Token price* is an input box you cannot type in, wearing a
+`READ-ONLY` chip to explain itself. The identity row's *Receive* and *Swap* are
+`ghost` buttons - no fill, no border at rest - and Receive's glyph is a QR
+matrix rasterised into 20px. Both were caught by eye on the 2026-07-29 walk.
+
+**Source:** Jakub's walk notes, 2026-07-29. **Status:** _pending pick_.
+
+---
+
+## S1 · Read-only Token price
+
+| | variant | what changes | light-mode AA |
+|---|---|---|---|
+| | Today | box + chip, value at `textPrimary` | pass |
+| ★ | **A · Detail row** | stops being a field; becomes a `GWDetailGrid` row like `Total` | **pass** |
+| | B · Quiet field | no chip, no edge, value dimmed | **4.23:1 FAIL** |
+| | C · Locked field | no chip, lock glyph, value dimmed | **4.23:1 FAIL** |
+| | D · Prefixed | no chip, no edge, full-weight value, `· live` label | pass |
+
+**The measurement that shapes this.** "Just grey the value out" is the obvious
+move and it is not free: `textSecondary` on `surfaceSunken` is **6.20:1 dark**
+but **4.23:1 light**, under the 4.5:1 body floor. Variants that dim the value
+(B, C) carry that debt; variants that change the *frame* instead (A, D) do not.
+
+**★ A · Detail row.** The only variant where the control is not an input, which
+outranks any label an input can wear. The card already ships that exact row one
+line below (`Total`), so it costs no new language. It keeps `textPrimary`, so
+no contrast debt. And it removes a wart the code comments already name: a
+`readOnly` field still takes focus in Flutter, so today's box can be tabbed
+into and lights up promising an edit that cannot happen.
+
+**Runner-up C · Locked field** - keeps the Convert card's two-input symmetry,
+which is defensible for a calculator. Needs a light-mode answer first.
+
+**Rejected D · Prefixed** - a box with no tag, no lock and a full-weight value
+is close to the state that caused someone to add the chip. Removing the signal
+without replacing it re-opens the original defect.
+
+---
+
+## S2 · Receive / Swap action icons
+
+Two independent defects, deliberately separated because fixing one does not fix
+the other:
+
+1. **The glyph.** `Icons.qr_code_2` is a finder-square-plus-data-field matrix -
+   20-odd sub-3px shapes inside a 20px box. It resolves as noise.
+2. **The container.** `variant: ghost` paints nothing at rest, so both actions
+   float beside a 26px coin name with no boundary saying they are pressable.
+
+| | variant | container | glyph | colour |
+|---|---|---|---|---|
+| | Today | ghost (none) | `qr_code_2` | `textPrimary` |
+| | A · Contained | `variant: icon` (exists) | unchanged | `textPrimary` |
+| ★ | **C · Contained + tint** | `variant: icon` | `call_received` | `brandPrimary` |
+| | D · Labelled pills | tertiary + label | any | `textPrimary` |
+
+**★ C.** The container is the half that matters. `GWButton` already has a
+`variant: icon` (`surfaceElevated` fill + `borderSubtle` edge), so it is a
+one-word change rather than a new component. `brandPrimary` on
+`surfaceElevated` measures **9.86:1 dark / 6.30:1 light**, far above the 3:1 a
+non-text glyph needs. The tint stays on the glyph - a filled brand button here
+would break the CTA weight rule (fill = commitment, one per surface).
+
+**The glyph swap is separable and is Jakub's call, not mine.** `call_received`
+resolves at any size because it is two strokes; `qr_code_2` carries the meaning
+"there is a code to scan", and the drawer it opens *is* a QR code. Real trade.
+
+**Rejected D** - the most legible option, and still rejected: the identity row
+already carries a 26px name, a symbol, a network and a 30px price, and a third
+action (Bridge) appears on GNUS coins. Three labelled pills is a toolbar
+competing with the heading.
+
+---
+
+## Grounding
+
+- `GWButton` sizes/variants: `lib/components/buttons/gw_button.dart` -
+  `md` = 48px box, 20px glyph; `ghost` = transparent + no border;
+  `icon` = `surfaceElevated` + `borderSubtle`.
+- `GWTextField` read-only call site: `lib/tokens/token_info_screen.dart`.
+- Tokens: `lib/theme/genius_wallet_colors.dart`.
+- All contrast figures computed against composited values, not quoted.
+
+## Not in scope
+
+The Markets hero chart. It has a measured layout blocker attached (the card
+grows by the chart's full delta) so it is a layout decision, not a styling one,
+and is written up separately.

--- a/.planning/sketches/164-readonly-and-action-icons/index.html
+++ b/.planning/sketches/164-readonly-and-action-icons/index.html
@@ -1,0 +1,430 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Sketch 164 - Read-only field + coin-page action icons</title>
+<style>
+  :root{
+    --surface-base:#0B0D12; --surface-elevated:#0C0E14; --surface-menu:#171A21; --surface-sunken:#06080C;
+    --text-primary:#FFFFFF; --text-secondary:#8A8F9D; --text-p54:rgba(255,255,255,.54);
+    --border-subtle:rgba(255,255,255,.12); --border-strong:rgba(255,255,255,.24); --border-control:rgba(255,255,255,.36);
+    --brand:#14C8FF; --success:#0AD89C; --error:#FF4D4D;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--surface-base);color:var(--text-primary);
+       font:14px/20px -apple-system,BlinkMacSystemFont,"Inter","Segoe UI",sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1360px;margin:0 auto;padding:32px 24px 140px}
+  h1{font-size:26px;line-height:34px;margin:0 0 6px;letter-spacing:-.02em}
+  h2{font-size:18px;line-height:26px;margin:36px 0 8px}
+  h3{font-size:14px;line-height:20px;margin:22px 0 6px}
+  p{margin:0 0 10px}
+  .lede{color:var(--text-secondary);max-width:92ch}
+  .note{color:var(--text-secondary);font-size:12px;line-height:18px;max-width:92ch}
+  code{font-family:"JetBrains Mono",ui-monospace,monospace;font-size:12px;background:var(--surface-menu);
+       padding:1px 5px;border-radius:4px;color:#CBD2DC}
+  table{border-collapse:collapse;margin:10px 0 14px;font-size:12px}
+  th,td{border:1px solid rgba(255,255,255,.12);padding:5px 10px;text-align:left}
+  th{color:var(--text-secondary);font-weight:600;text-transform:uppercase;letter-spacing:.06em;font-size:10px}
+  .pass{color:#0AD89C;font-weight:700} .fail{color:#FF4D4D;font-weight:700}
+
+  .bar-ctl{display:flex;gap:22px;flex-wrap:wrap;align-items:center;margin:20px 0 8px;
+           padding:14px 16px;background:var(--surface-elevated);border:1px solid var(--border-subtle);border-radius:12px;
+           position:sticky;top:0;z-index:20}
+  .grp{display:flex;gap:6px;align-items:center;flex-wrap:wrap}
+  .grp > .lab{font-size:10px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;
+              color:var(--text-secondary);margin-right:2px}
+  .chip{padding:6px 12px;border:1px solid var(--border-subtle);border-radius:999px;background:transparent;
+        color:var(--text-secondary);font-size:12px;font-weight:600;cursor:pointer;font-family:inherit}
+  .chip[aria-pressed="true"]{border-color:var(--brand);color:var(--brand);background:rgba(20,200,255,.10)}
+
+  /* ---------- stage: 1:1, never scaled ---------- */
+  .stage{margin-top:16px;padding:24px;border-radius:12px;background:var(--surface-base);
+         border:1px dashed rgba(20,200,255,.30);overflow-x:auto}
+  .stage.light{--surface-base:#DCE0E6;--surface-elevated:#FFFFFF;--surface-menu:#EFF2F6;--surface-sunken:#CFD4DB;
+        --text-primary:#10131A;--text-secondary:#5A606E;--text-p54:rgba(16,19,26,.54);
+        --border-subtle:rgba(16,19,26,.12);--border-strong:rgba(16,19,26,.24);--border-control:rgba(16,19,26,.46);
+        --brand:#0A6885;--success:#07875F;--error:#D92D2D}
+  .stage.light .card{color:#10131A}
+  .row{display:flex;gap:28px;align-items:flex-start;flex-wrap:wrap}
+  .cell{flex:none}
+  .cap{font:600 11px/16px "JetBrains Mono",ui-monospace,monospace;letter-spacing:.04em;
+       margin-bottom:8px;text-transform:uppercase;color:var(--text-secondary)}
+  .cap.good{color:var(--success)} .cap.bad{color:var(--error)} .cap.rec{color:var(--brand)}
+
+  /* ---------- GWCard: radiusMd 12, padding space8 16, surfaceElevated + borderSubtle ---------- */
+  .card{width:462px;background:var(--surface-elevated);border:1px solid var(--border-subtle);
+        border-radius:12px;padding:16px}
+  .sect{font:600 13px/18px inherit;letter-spacing:.5px;text-transform:uppercase;color:var(--text-secondary);
+        margin-bottom:12px}
+
+  /* ---------- GWTextField: label above at labelMd/textSecondary, box radiusMd ---------- */
+  .fld{margin-bottom:12px}
+  .fld .flabel{font:600 12px/16px inherit;color:var(--text-secondary);margin-bottom:8px}
+  .box{height:48px;border-radius:12px;background:var(--surface-sunken);border:1px solid var(--border-subtle);
+       display:flex;align-items:center;padding:0 14px;gap:10px}
+  .box .val{font:400 16px/20px "JetBrains Mono",ui-monospace,monospace;flex:1}
+  .box.editable{border-color:var(--border-control)}
+  .box.noborder{border-color:transparent}
+  .val.dim{color:var(--text-secondary)}
+  .tag{font:600 10px/14px inherit;letter-spacing:.06em;color:var(--text-p54);
+       border:1px solid var(--border-subtle);border-radius:4px;padding:1px 4px}
+
+  /* GWDetailGrid row: kGWDetailRowPadding, hairline between rows */
+  .dgrid{border:1px solid var(--border-subtle);border-radius:12px;overflow:hidden;background:var(--surface-sunken)}
+  .drow{display:flex;justify-content:space-between;align-items:center;padding:12px 14px}
+  .drow + .drow{border-top:1px solid var(--border-subtle)}
+  .drow .k{font:400 13px/18px inherit;color:var(--text-secondary)}
+  .drow .v{font:600 15px/20px "JetBrains Mono",ui-monospace,monospace;color:var(--text-primary)}
+  .drow.total .k{color:var(--text-primary)}
+
+  /* ---------- GWButton.icon: md = 48x48, glyph 20px ---------- */
+  .idrow{display:flex;align-items:center;gap:0}
+  .ibtn{width:48px;height:48px;border-radius:12px;display:grid;place-items:center;
+        background:transparent;border:1px solid transparent;cursor:pointer}
+  .ibtn svg{width:20px;height:20px;display:block}
+  .ibtn.ghost{background:transparent;border-color:transparent}
+  .ibtn.contained{background:var(--surface-elevated);border-color:var(--border-subtle)}
+  .ibtn.contained.onelev{background:var(--surface-menu)}
+  .ibtn.tint svg{color:var(--brand)}
+  .hovered .ibtn.ghost{background:var(--surface-menu)}
+  .hovered .ibtn.contained{background:var(--surface-menu);border-color:var(--border-control);transform:translateY(-1px)}
+  .idrow.spaced{gap:8px}
+  .pill{height:48px;border-radius:12px;display:inline-flex;align-items:center;gap:8px;padding:0 16px;
+        background:var(--surface-elevated);border:1px solid var(--border-subtle);cursor:pointer}
+  .pill svg{width:20px;height:20px} .pill span{font:600 15px/20px inherit}
+
+  /* identity row so the icons are judged in situ, never in a vacuum */
+  .ident{display:flex;align-items:center;gap:12px}
+  .ident .dot{width:40px;height:40px;border-radius:999px;background:#F7931A;display:grid;place-items:center;
+              font:700 18px/1 inherit;color:#101319}
+  .ident .nm{font:700 26px/32px inherit;letter-spacing:-.02em}
+  .glyphrow{display:flex;gap:22px;align-items:flex-end;flex-wrap:wrap}
+  .gcell{text-align:center;width:120px}
+  .gcell .gbox{width:48px;height:48px;margin:0 auto 6px;display:grid;place-items:center;
+               border:1px dashed rgba(20,200,255,.30);border-radius:12px}
+  .gcell .gbox svg{width:20px;height:20px}
+  .gcell .gname{font:600 10px/14px "JetBrains Mono",ui-monospace,monospace;color:var(--text-secondary)}
+  .rec{border-left:3px solid var(--brand);padding:2px 0 2px 14px;margin:14px 0}
+  .rej{border-left:3px solid var(--error);padding:2px 0 2px 14px;margin:14px 0}
+  .run{border-left:3px solid var(--text-secondary);padding:2px 0 2px 14px;margin:14px 0}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<h1>Sketch 164 · Read-only field + coin-page action icons</h1>
+<p class="lede">
+  Two questions off the 2026-07-29 walk, both on the coin page, both about the same thing:
+  <strong>a control has to say what it is before it says anything else.</strong>
+  S1 asks how a value you cannot edit should look. S2 asks how the Receive / Swap actions should look
+  when they sit next to a 26px coin name. Everything below is at 1:1 and built from the real tokens.
+</p>
+
+<div class="bar-ctl">
+  <div class="grp"><span class="lab">Theme</span>
+    <button class="chip" id="t-dark" aria-pressed="true">Dark</button>
+    <button class="chip" id="t-light" aria-pressed="false">Light</button>
+  </div>
+  <div class="grp"><span class="lab">Icon state</span>
+    <button class="chip" id="s-rest" aria-pressed="true">Rest</button>
+    <button class="chip" id="s-hover" aria-pressed="false">Hover</button>
+  </div>
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<h2>S1 · The read-only Token price</h2>
+<p class="note">
+  Today: a <code>GWTextField</code> with <code>readOnly: true</code>, a <code>surfaceSunken</code> fill, the
+  component's default <code>borderSubtle</code> edge, the value at full <code>textPrimary</code>, and a
+  bordered <strong>READ-ONLY</strong> chip in the <code>suffix</code> slot. The chip is doing the entire job of
+  saying "not yours", because nothing else on the box says it - it is the same height, the same radius and
+  nearly the same edge as the field directly beneath it, which you <em>can</em> type in.
+</p>
+
+<h3>The constraint that decides this</h3>
+<p class="note">
+  The obvious move - grey the value out - is not free. Measured against the fill it would sit on:
+</p>
+<table>
+  <tr><th>pairing</th><th>dark</th><th>light</th><th>AA body 4.5:1</th></tr>
+  <tr><td><code>textSecondary</code> on <code>surfaceSunken</code></td><td>6.20:1</td><td>4.23:1</td>
+      <td><span class="pass">pass</span> / <span class="fail">FAIL light</span></td></tr>
+  <tr><td><code>textPrimary</code> on <code>surfaceSunken</code></td><td>20.04:1</td><td>12.47:1</td>
+      <td><span class="pass">pass both</span></td></tr>
+  <tr><td><code>textPrimary54</code> on <code>surfaceSunken</code> (today's chip)</td><td>6.03:1</td><td>-</td>
+      <td><span class="pass">pass</span></td></tr>
+</table>
+<p class="note">
+  So "just grey the font" ships an AA failure in light mode at <strong>4.23:1</strong>. Any variant below that
+  dims the value has to carry that cost or pick a different fill; the ones that keep the value at
+  <code>textPrimary</code> and change the <em>frame</em> instead have no such problem.
+</p>
+
+<div class="stage" id="stage1">
+  <div class="row">
+
+    <div class="cell">
+      <div class="cap bad">Today · chip carries it all</div>
+      <div class="card">
+        <div class="sect">Convert</div>
+        <div class="fld"><div class="flabel">Token price</div>
+          <div class="box"><span class="val">63514.0</span><span class="tag">READ-ONLY</span></div></div>
+        <div class="fld"><div class="flabel">Token amount</div>
+          <div class="box editable"><span class="val">1</span></div></div>
+        <div class="dgrid"><div class="drow total"><span class="k">Total</span><span class="v">$63,514.00</span></div></div>
+      </div>
+    </div>
+
+    <div class="cell">
+      <div class="cap rec">A · Detail row (recommended)</div>
+      <div class="card">
+        <div class="sect">Convert</div>
+        <div class="dgrid" style="margin-bottom:12px">
+          <div class="drow"><span class="k">Token price</span><span class="v">$63,514.00</span></div>
+        </div>
+        <div class="fld"><div class="flabel">Token amount</div>
+          <div class="box editable"><span class="val">1</span></div></div>
+        <div class="dgrid"><div class="drow total"><span class="k">Total</span><span class="v">$63,514.00</span></div></div>
+      </div>
+      <p class="note" style="width:462px;margin-top:10px">
+        Stops being a field. The card already speaks this language one row down - <code>Total</code> is a
+        <code>GWDetailGrid</code> row - so the price joins the facts instead of impersonating an input.
+        Value stays <code>textPrimary</code>, so no contrast cost in either mode.
+      </p>
+    </div>
+
+    <div class="cell">
+      <div class="cap">B · Quiet field · dimmed, no edge</div>
+      <div class="card">
+        <div class="sect">Convert</div>
+        <div class="fld"><div class="flabel">Token price</div>
+          <div class="box noborder"><span class="val dim">63514.0</span></div></div>
+        <div class="fld"><div class="flabel">Token amount</div>
+          <div class="box editable"><span class="val">1</span></div></div>
+        <div class="dgrid"><div class="drow total"><span class="k">Total</span><span class="v">$63,514.00</span></div></div>
+      </div>
+      <p class="note" style="width:462px;margin-top:10px">
+        Jakub's own description: no tag, greyed font, a background that reads as inert. Removing the edge is
+        what makes it work - a dimmed value inside a bordered box still looks like a disabled input you could
+        re-enable. <strong>Carries the 4.23:1 light-mode failure.</strong>
+      </p>
+    </div>
+
+    <div class="cell">
+      <div class="cap">C · Locked field</div>
+      <div class="card">
+        <div class="sect">Convert</div>
+        <div class="fld"><div class="flabel">Token price</div>
+          <div class="box"><span class="val dim">63514.0</span>
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8"
+                 style="color:var(--text-secondary)">
+              <rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>
+          </div></div>
+        <div class="fld"><div class="flabel">Token amount</div>
+          <div class="box editable"><span class="val">1</span></div></div>
+        <div class="dgrid"><div class="drow total"><span class="k">Total</span><span class="v">$63,514.00</span></div></div>
+      </div>
+      <p class="note" style="width:462px;margin-top:10px">
+        Swaps six words of shouting for one 16px glyph and keeps the two fields visually symmetrical.
+        Same light-mode contrast cost as B.
+      </p>
+    </div>
+
+    <div class="cell">
+      <div class="cap">D · Prefixed, full weight</div>
+      <div class="card">
+        <div class="sect">Convert</div>
+        <div class="fld"><div class="flabel">Token price · live</div>
+          <div class="box noborder"><span class="val" style="color:var(--text-secondary)">$</span><span class="val" style="flex:0">63,514.00</span><span style="flex:1"></span></div></div>
+        <div class="fld"><div class="flabel">Token amount</div>
+          <div class="box editable"><span class="val">1</span></div></div>
+        <div class="dgrid"><div class="drow total"><span class="k">Total</span><span class="v">$63,514.00</span></div></div>
+      </div>
+      <p class="note" style="width:462px;margin-top:10px">
+        Keeps full contrast and leans entirely on absence-of-affordance plus a "· live" qualifier.
+        Honest about where the number comes from, weakest at saying you cannot touch it.
+      </p>
+    </div>
+
+  </div>
+</div>
+
+<div class="rec">
+  <strong>★ A · Detail row.</strong> Four reasons, in order of weight: it is the only variant where the control
+  <em>is not an input</em>, which is a stronger statement than any label on an input can make; the card already
+  ships that exact row one line below, so it costs no new language and no new component; it keeps the value at
+  <code>textPrimary</code> and therefore has no light-mode contrast debt; and it removes a wart the code comments
+  already complain about - a <code>readOnly</code> field still takes focus in Flutter, so today's box can be
+  tabbed into and light up promising an edit that cannot happen.
+</div>
+<div class="run">
+  <strong>Runner-up: C · Locked field.</strong> If the two-field symmetry of the Convert card is worth keeping -
+  and there is a real argument that it is, since the card is a calculator and calculators have input rows - C is
+  the cheapest honest version. It needs a light-mode answer for the dimmed value first.
+</div>
+<div class="rej">
+  <strong>Rejected: D · Prefixed.</strong> A box with no tag, no lock and a full-weight value is close to the
+  state that made someone add the READ-ONLY chip in the first place. Removing the chip without replacing the
+  signal re-opens the original defect.
+</div>
+
+<!-- ══════════════════════════════════════════════════════════════════ -->
+<h2>S2 · The Receive / Swap action icons</h2>
+<p class="note">
+  Today both are <code>GWButton.icon(variant: ghost, size: md)</code> - 48x48, glyph 20px,
+  <code>textPrimary</code>, <strong>transparent fill and no border at rest</strong>. Two separate things are wrong
+  and they need separating, because fixing one does not fix the other.
+</p>
+<p class="note">
+  <strong>1 · The glyph.</strong> <code>Icons.qr_code_2</code> is a dense 2D matrix - finder squares plus a data
+  field. Rasterised into 20px it stops being a QR code and becomes noise, which is exactly what the walk
+  screenshot shows. <strong>2 · The container.</strong> <code>ghost</code> draws nothing at rest, so both actions
+  float beside a 26px coin name with no edge to say they are pressable.
+</p>
+
+<h3>The Receive glyph, at the real 20px</h3>
+<div class="stage" id="stage2a">
+  <div class="glyphrow">
+    <div class="gcell"><div class="gbox">
+      <svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 3h7v7H3V3zm2 2v3h3V5H5zM3 14h7v7H3v-7zm2 2v3h3v-3H5zM14 3h7v7h-7V3zm2 2v3h3V5h-3zM14 14h2v2h-2v-2zm3 0h2v2h-2v-2zm2 2h2v2h-2v-2zm-5 1h2v2h-2v-2zm3 1h2v3h-2v-3zm-3 3h2v2h-2v-2zm3 0h4v2h-4v-2z"/></svg>
+    </div><div class="gname">qr_code_2<br>TODAY</div></div>
+    <div class="gcell"><div class="gbox">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><path d="M14 14h3v3h-3z"/><path d="M20 20h1M17 20v1"/></svg>
+    </div><div class="gname">qr_code<br>lighter matrix</div></div>
+    <div class="gcell"><div class="gbox">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L7 17"/><path d="M17 17H7V7"/></svg>
+    </div><div class="gname">call_received<br>arrow in</div></div>
+    <div class="gcell"><div class="gbox">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="M7 10l5 5 5-5"/><path d="M4 20h16"/></svg>
+    </div><div class="gname">download / to-line<br>arrow to floor</div></div>
+    <div class="gcell"><div class="gbox">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 8h13"/><path d="M13 4l4 4-4 4"/><path d="M20 16H7"/><path d="M11 12l-4 4 4 4"/></svg>
+    </div><div class="gname">swap_horiz<br>SWAP · unchanged</div></div>
+  </div>
+  <p class="note" style="margin-top:16px">
+    Read them small and the ranking is not close. <code>qr_code_2</code> fills its 20px box with 20-odd
+    sub-3px shapes; <code>call_received</code> resolves at any size because it is two strokes. The counter-argument
+    is meaning: an arrow says "incoming", a matrix says "there is a code to scan", and the drawer this opens
+    <em>is</em> a QR code. That is a real trade and it belongs to Jakub, not to me.
+  </p>
+</div>
+
+<h3>The container, judged in situ</h3>
+<div class="stage" id="stage2b">
+  <div class="row">
+
+    <div class="cell">
+      <div class="cap bad">Today · ghost, no edge</div>
+      <div class="ident">
+        <div class="dot">B</div><div class="nm">Bitcoin</div>
+        <div class="idrow">
+          <div class="ibtn ghost"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M3 3h7v7H3V3zm2 2v3h3V5H5zM3 14h7v7H3v-7zm2 2v3h3v-3H5zM14 3h7v7h-7V3zm2 2v3h3V5h-3zM14 14h2v2h-2v-2zm3 0h2v2h-2v-2zm2 2h2v2h-2v-2zm-5 1h2v2h-2v-2zm3 1h2v3h-2v-3zm-3 3h2v2h-2v-2zm3 0h4v2h-4v-2z"/></svg></div>
+          <div class="ibtn ghost"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 8h13"/><path d="M13 4l4 4-4 4"/><path d="M20 16H7"/><path d="M11 12l-4 4 4 4"/></svg></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="cell">
+      <div class="cap">A · Contained</div>
+      <div class="ident">
+        <div class="dot">B</div><div class="nm">Bitcoin</div>
+        <div class="idrow spaced">
+          <div class="ibtn contained"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L7 17"/><path d="M17 17H7V7"/></svg></div>
+          <div class="ibtn contained"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 8h13"/><path d="M13 4l4 4-4 4"/><path d="M20 16H7"/><path d="M11 12l-4 4 4 4"/></svg></div>
+        </div>
+      </div>
+      <p class="note" style="width:340px;margin-top:12px">
+        <code>variant: ghost</code> → <code>variant: icon</code>. That variant already exists in
+        <code>GWButton</code> - <code>surfaceElevated</code> fill, <code>borderSubtle</code> edge - so this is a
+        one-word change, not a new component.
+      </p>
+    </div>
+
+    <div class="cell">
+      <div class="cap rec">C · Contained + brand glyph (recommended)</div>
+      <div class="ident">
+        <div class="dot">B</div><div class="nm">Bitcoin</div>
+        <div class="idrow spaced">
+          <div class="ibtn contained tint"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L7 17"/><path d="M17 17H7V7"/></svg></div>
+          <div class="ibtn contained tint"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 8h13"/><path d="M13 4l4 4-4 4"/><path d="M20 16H7"/><path d="M11 12l-4 4 4 4"/></svg></div>
+        </div>
+      </div>
+      <p class="note" style="width:340px;margin-top:12px">
+        A plus the colour that was asked for. <code>brandPrimary</code> on <code>surfaceElevated</code> measures
+        <strong>9.86:1 dark / 6.30:1 light</strong> - far above the 3:1 a non-text glyph needs, and it is the
+        app's own accent rather than a new hue. The tint stays on the <em>glyph</em>: a filled brand button here
+        would break the CTA weight rule, which reserves fill for commitment and allows one per surface.
+      </p>
+    </div>
+
+    <div class="cell">
+      <div class="cap">D · Labelled pills</div>
+      <div class="ident">
+        <div class="dot">B</div><div class="nm">Bitcoin</div>
+        <div class="idrow spaced">
+          <div class="pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L7 17"/><path d="M17 17H7V7"/></svg><span>Receive</span></div>
+          <div class="pill"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 8h13"/><path d="M13 4l4 4-4 4"/><path d="M20 16H7"/><path d="M11 12l-4 4 4 4"/></svg><span>Swap</span></div>
+        </div>
+      </div>
+      <p class="note" style="width:340px;margin-top:12px">
+        Unambiguous, and it removes the glyph question entirely. Costs about 210px of the identity row and turns
+        a coin heading into a toolbar - and there is a third button (Bridge) on GNUS-enabled coins.
+      </p>
+    </div>
+
+  </div>
+</div>
+
+<div class="rec">
+  <strong>★ C · Contained + brand glyph, with <code>call_received</code> for Receive.</strong> The container is the
+  half that matters: a control identified only by its glyph has no resting boundary, and the walk found it by
+  eye without being told to look. Tinting the glyph answers the "add some colour" ask without spending the one
+  filled CTA a surface is allowed. The glyph swap is separable - take the container and keep
+  <code>qr_code_2</code> if the QR meaning is worth more than the legibility, but do not leave both as they are.
+</div>
+<div class="run">
+  <strong>Runner-up: A · Contained, glyph unchanged.</strong> Everything C fixes structurally, none of the
+  colour. Pick this if the brand tint on two secondary actions reads as too loud next to the price.
+</div>
+<div class="rej">
+  <strong>Rejected: D · Labelled pills.</strong> Not because it is wrong - it is the most legible option on the
+  page - but because the identity row already carries a 26px name, a symbol, a network and a 30px price, and a
+  third action appears on GNUS coins. Three labelled pills there is a toolbar competing with the heading.
+</div>
+
+<h2>What this sketch does NOT decide</h2>
+<p class="note">
+  The Markets hero chart. It is a different question with a measured blocker attached - the card grows by the
+  chart's full delta, so any taller frame there is a layout decision, not a styling one - and it is written up
+  separately rather than smuggled in here.
+</p>
+
+<script>
+  (function () {
+    var stages = ['stage1', 'stage2a', 'stage2b'].map(function (id) { return document.getElementById(id); });
+
+    function setTheme(light) {
+      stages.forEach(function (s) { if (s) { s.classList.toggle('light', light); } });
+      document.getElementById('t-dark').setAttribute('aria-pressed', String(!light));
+      document.getElementById('t-light').setAttribute('aria-pressed', String(light));
+    }
+
+    function setHover(on) {
+      stages.forEach(function (s) { if (s) { s.classList.toggle('hovered', on); } });
+      document.getElementById('s-rest').setAttribute('aria-pressed', String(!on));
+      document.getElementById('s-hover').setAttribute('aria-pressed', String(on));
+    }
+
+    document.getElementById('t-dark').addEventListener('click', function () { setTheme(false); });
+    document.getElementById('t-light').addEventListener('click', function () { setTheme(true); });
+    document.getElementById('s-rest').addEventListener('click', function () { setHover(false); });
+    document.getElementById('s-hover').addEventListener('click', function () { setHover(true); });
+
+    setTheme(false);
+    setHover(false);
+  })();
+</script>
+
+</div>
+</body>
+</html>

--- a/.planning/todos/pending/2026-07-30-four-list-rows-still-outside-gw-hover-row.md
+++ b/.planning/todos/pending/2026-07-30-four-list-rows-still-outside-gw-hover-row.md
@@ -1,0 +1,42 @@
+---
+created: 2026-07-30T00:00:00.000Z
+title: Four tappable list rows are still outside GWHoverRow
+area: ui
+files:
+  - lib/submit_job/view/widgets/job_step_list.dart:161
+  - lib/account/sdk_account_manager.dart:710
+  - lib/logs/submit_logs_screen.dart:661
+  - lib/dashboard/bridge/bridge_screen.dart:824
+---
+
+## Problem
+
+`GWHoverRow` (2026-07-30) unified the row hover across the five lists Jakub named: Transactions,
+the Markets page table, the dashboard Markets panel, Assets, and `GWTokenRow`. A sweep of every
+`ListTile` with an `onTap` and every bare `InkWell` in `lib/` turned up **four more tappable rows**
+that were deliberately left alone as outside that scope.
+
+They carry the same two defects the sweep was created to fix:
+
+| File | Defect |
+|---|---|
+| `job_step_list.dart:161` | bare `InkWell(onTap:, child:)`, **no `borderRadius`** - square highlight |
+| `sdk_account_manager.dart:710` | bare `InkWell`, same |
+| `submit_logs_screen.dart:661` | bare `InkWell`, same |
+| `bridge_screen.dart:824` | `ListTile` with `onTap` - the **buried-ink** trap: a `ListTile` paints its highlight on the nearest ANCESTOR `Material`, so if that ancestor sits under a painted panel background the hover is invisible, which is exactly why Assets and the dashboard Markets panel appeared to have no hover at all |
+
+Everything else the sweep matched is a button, card, checkbox or switch - those have their own
+affordances and `GWHoverRow` would be wrong there.
+
+## Solution
+
+Wrap each in `GWHoverRow` and drop the local `InkWell`/`ListTile.onTap`. The component brings its
+own transparent `Material`, `radiusMd`, click cursor and the 6% `kGWRowHoverAlpha` highlight.
+
+**Check the `ListTile` case by eye, not by test**: whether its ink was buried depends on what the
+caller paints, and only `bridge_screen.dart:824` is a `ListTile` here.
+
+## Not in scope of this todo
+
+`GWHoverable` (Phase 23-05) is builder-style state plumbing that hands the caller a `bool` - it
+composes with `GWHoverRow` rather than replacing it.

--- a/lib/chart/crypto_live_chart.dart
+++ b/lib/chart/crypto_live_chart.dart
@@ -576,40 +576,65 @@ class _ChartHeaderRow extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final bool narrow = constraints.maxWidth < _narrowWidth;
+        // The readouts take ONE `Expanded`; the segment takes what is left.
+        //
+        // This was a loose `Flexible` for the price followed by a `Spacer`, and
+        // that is the identical defect `gw_page_header.dart` was fixed for on
+        // 2026-07-29: both default to `flex: 1`, so they split the row's free
+        // space 50/50. A price that does not spend its half does not hand the
+        // remainder back — `RenderFlex` distributes the shortfall by
+        // `MainAxisAlignment`, which defaults to `start`, so it lands AFTER the
+        // last child. The segment was therefore parked short of the right edge
+        // with a band of dead space beyond it, which is exactly what the walk
+        // caught ("time frame to the right"). One flex child cannot mis-split
+        // anything.
         return Row(
           children: [
-            Flexible(
-              child: Text(
-                formattedPrice,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontSize: narrow ? 15 : 17,
-                  fontWeight: FontWeight.bold,
-                  color: gw.textPrimary,
-                  fontFeatures: const [FontFeature.tabularFigures()],
-                ),
+            Expanded(
+              child: Row(
+                children: [
+                  Flexible(
+                    child: Text(
+                      formattedPrice,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: narrow ? 15 : 17,
+                        fontWeight: FontWeight.bold,
+                        color: gw.textPrimary,
+                        fontFeatures: const [FontFeature.tabularFigures()],
+                      ),
+                    ),
+                  ),
+                  if (hasData) ...[
+                    const SizedBox(width: GeniusWalletConsts.space4),
+                    Text(
+                      "${percentChange >= 0 ? "+" : ""}${percentChange.toStringAsFixed(2)}%",
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                        color: trendColor,
+                      ),
+                    ),
+                    if (!narrow) ...[
+                      const SizedBox(width: GeniusWalletConsts.space4),
+                      Flexible(
+                        child: Text(
+                          timeLabel,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: gw.textSecondary,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ],
               ),
             ),
-            if (hasData) ...[
-              const SizedBox(width: GeniusWalletConsts.space4),
-              Text(
-                "${percentChange >= 0 ? "+" : ""}${percentChange.toStringAsFixed(2)}%",
-                style: TextStyle(
-                  fontSize: 12,
-                  fontWeight: FontWeight.bold,
-                  color: trendColor,
-                ),
-              ),
-              if (!narrow) ...[
-                const SizedBox(width: GeniusWalletConsts.space4),
-                Text(
-                  timeLabel,
-                  style: TextStyle(fontSize: 11, color: gw.textSecondary),
-                ),
-              ],
-            ],
-            const Spacer(),
+            const SizedBox(width: GeniusWalletConsts.space4),
             const GWTimeframeSegment(),
           ],
         );

--- a/lib/chart/crypto_simple_chart.dart
+++ b/lib/chart/crypto_simple_chart.dart
@@ -1,5 +1,6 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:genius_wallet/components/effects/gw_hover_row.dart';
 import 'package:genius_wallet/theme/genius_wallet_typography.dart';
 import 'package:genius_wallet/theme/gw_colors.dart';
 import 'package:genius_wallet/utils/image_utils.dart';
@@ -60,105 +61,120 @@ class CryptoSparkLineChart extends StatelessWidget {
       decimalDigits: tokenDecimalsToDisplay,
     ).format(currentPrice);
 
-    return ListTile(
-      leading: buildTokenIcon(iconPath: iconPath, size: iconSize),
-      // NAME is primary (titleMd / textPrimary), price secondary (bodySm /
-      // textSecondary) — mirrors the Assets CoinCardRow hierarchy.
-      // A FIXED style with an ellipsis, never AutoSizeText. AutoSizeText
-      // searches for a font size that fits the box, so as the window is
-      // drag-resized it emits a different size — and therefore a different
-      // TextStyle, and therefore a different skia ParagraphCacheKey — on
-      // essentially every frame. With one of these per market row, that fills
-      // and evicts the fixed-size cache continuously, layout never settles,
-      // no frame is ever committed, and the macOS embedder blocks forever in
-      // ResizeSynchronizer.beginResize. That is the freeze commit 37639d5
-      // diagnosed; 37639d5 only quantised the OTHER site's height-derived
-      // font size and left this width-driven search in place.
-      title: Text(
-        title,
-        style: GeniusWalletTypography.titleMd.copyWith(color: gw.textPrimary),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      ),
+    // The dashboard Markets panel is the FOURTH tappable list, and it went
+    // missing from the 2026-07-30 hover sweep: the Markets *page* table and
+    // this panel look like one feature but are two widgets, and only the table
+    // was migrated. Same `ListTile` failure as Assets - the tile draws its
+    // highlight on the nearest ancestor `Material`, which on the dashboard sits
+    // beneath the panel's own background, so it was painted and then covered.
+    //
+    // `GWHoverRow` brings its own transparent `Material` above that paint and
+    // clips to `radiusMd`. The tile keeps its layout and gives up only its tap:
+    // two ink responses stacked on one row would double the highlight.
+    return GWHoverRow(
       onTap: onTap,
-      // Ticker · price when a symbol is given (Jakub 2026-07-24 — "add the
-      // ticker if there's room"); ellipsis so a long pair degrades gracefully
-      // in the narrow dashboard panel rather than overflowing.
-      subtitle: Text(
-        symbol != null && symbol!.isNotEmpty
-            ? '${symbol!.toUpperCase()} · $formattedPrice'
-            : formattedPrice,
-        style: GeniusWalletTypography.bodySm.copyWith(color: gw.textSecondary),
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-      ),
-      titleAlignment: ListTileTitleAlignment.center,
-      // Order: % chip, then the sparkline as the LAST (rightmost) column
-      // (Jakub 2026-07-24). textDirection.rtl flips the child order without
-      // moving the big LineChart block: the first child (sparkline) lays out on
-      // the right, the last (% chip) on the left. Each child's own text keeps
-      // the app's LTR Directionality, so "+2.4%" renders normally.
-      trailing: Row(
-        textDirection: TextDirection.rtl,
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          // Same sparkline geometry as the Markets TAB's table column
-          // (markets_table.dart:310-318 — 72x32, barWidth 1.6) so the two
-          // renderings of the same data read as one component instead of the
-          // dashboard's being a visibly shrunk 56x20 copy. Jakub, 2026-07-25.
-          SizedBox(
-            width: 72,
-            height: 32,
-            child: LineChart(
-              LineChartData(
-                lineBarsData: [
-                  LineChartBarData(
-                    spots: getSparklineChartData(),
-                    isCurved: true,
-                    color: changeColor,
-                    barWidth: 1.6,
-                    dotData: const FlDotData(show: false),
+      semanticLabel: title,
+      child: ListTile(
+        leading: buildTokenIcon(iconPath: iconPath, size: iconSize),
+        // NAME is primary (titleMd / textPrimary), price secondary (bodySm /
+        // textSecondary) — mirrors the Assets CoinCardRow hierarchy.
+        // A FIXED style with an ellipsis, never AutoSizeText. AutoSizeText
+        // searches for a font size that fits the box, so as the window is
+        // drag-resized it emits a different size — and therefore a different
+        // TextStyle, and therefore a different skia ParagraphCacheKey — on
+        // essentially every frame. With one of these per market row, that fills
+        // and evicts the fixed-size cache continuously, layout never settles,
+        // no frame is ever committed, and the macOS embedder blocks forever in
+        // ResizeSynchronizer.beginResize. That is the freeze commit 37639d5
+        // diagnosed; 37639d5 only quantised the OTHER site's height-derived
+        // font size and left this width-driven search in place.
+        title: Text(
+          title,
+          style: GeniusWalletTypography.titleMd.copyWith(color: gw.textPrimary),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        // Ticker · price when a symbol is given (Jakub 2026-07-24 — "add the
+        // ticker if there's room"); ellipsis so a long pair degrades gracefully
+        // in the narrow dashboard panel rather than overflowing.
+        subtitle: Text(
+          symbol != null && symbol!.isNotEmpty
+              ? '${symbol!.toUpperCase()} · $formattedPrice'
+              : formattedPrice,
+          style: GeniusWalletTypography.bodySm.copyWith(
+            color: gw.textSecondary,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        titleAlignment: ListTileTitleAlignment.center,
+        // Order: % chip, then the sparkline as the LAST (rightmost) column
+        // (Jakub 2026-07-24). textDirection.rtl flips the child order without
+        // moving the big LineChart block: the first child (sparkline) lays out on
+        // the right, the last (% chip) on the left. Each child's own text keeps
+        // the app's LTR Directionality, so "+2.4%" renders normally.
+        trailing: Row(
+          textDirection: TextDirection.rtl,
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            // Same sparkline geometry as the Markets TAB's table column
+            // (markets_table.dart:310-318 — 72x32, barWidth 1.6) so the two
+            // renderings of the same data read as one component instead of the
+            // dashboard's being a visibly shrunk 56x20 copy. Jakub, 2026-07-25.
+            SizedBox(
+              width: 72,
+              height: 32,
+              child: LineChart(
+                LineChartData(
+                  lineBarsData: [
+                    LineChartBarData(
+                      spots: getSparklineChartData(),
+                      isCurved: true,
+                      color: changeColor,
+                      barWidth: 1.6,
+                      dotData: const FlDotData(show: false),
+                    ),
+                  ],
+                  titlesData: const FlTitlesData(
+                    leftTitles: AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    rightTitles: AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    topTitles: AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
+                    bottomTitles: AxisTitles(
+                      sideTitles: SideTitles(showTitles: false),
+                    ),
                   ),
-                ],
-                titlesData: const FlTitlesData(
-                  leftTitles: AxisTitles(
-                    sideTitles: SideTitles(showTitles: false),
-                  ),
-                  rightTitles: AxisTitles(
-                    sideTitles: SideTitles(showTitles: false),
-                  ),
-                  topTitles: AxisTitles(
-                    sideTitles: SideTitles(showTitles: false),
-                  ),
-                  bottomTitles: AxisTitles(
-                    sideTitles: SideTitles(showTitles: false),
-                  ),
+                  gridData: const FlGridData(show: false),
+                  borderData: FlBorderData(show: false),
+                  lineTouchData: const LineTouchData(enabled: false),
                 ),
-                gridData: const FlGridData(show: false),
-                borderData: FlBorderData(show: false),
-                lineTouchData: const LineTouchData(enabled: false),
               ),
             ),
-          ),
-          // space6 = 12
-          const SizedBox(width: 12),
-          // Filled % chip (status tint + status fg), like Assets.
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: changeColor.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Text(
-              "${priceChangePercent >= 0 ? "+" : ""}${priceChangePercent.toStringAsFixed(2)}%",
-              style: GeniusWalletTypography.labelMd.copyWith(
-                color: changeColor,
-                fontWeight: FontWeight.w600,
+            // space6 = 12
+            const SizedBox(width: 12),
+            // Filled % chip (status tint + status fg), like Assets.
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: changeColor.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                "${priceChangePercent >= 0 ? "+" : ""}${priceChangePercent.toStringAsFixed(2)}%",
+                style: GeniusWalletTypography.labelMd.copyWith(
+                  color: changeColor,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/components/cards/gw_token_row.dart
+++ b/lib/components/cards/gw_token_row.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:genius_wallet/components/effects/gw_hover_row.dart';
 import 'package:genius_wallet/theme/genius_wallet_consts.dart';
 import 'package:genius_wallet/theme/genius_wallet_typography.dart';
 import 'package:genius_wallet/theme/gw_colors.dart';
@@ -30,84 +31,84 @@ class GWTokenRow extends StatelessWidget {
     // Fail-soft read: registers the InheritedWidget dependency that forces
     // this const-instanced widget to rebuild on a live appearance toggle.
     final gw = Theme.of(context).extension<GWColors>() ?? GWColors.dark();
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(GeniusWalletConsts.radiusMd),
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: GeniusWalletConsts.space6,
-            vertical: GeniusWalletConsts.space4,
-          ),
-          child: Row(
-            children: [
-              SizedBox(
-                width: 40,
-                height: 40,
-                child:
-                    iconWidget ??
-                    (iconAsset != null
-                        ? Image.asset(
-                            iconAsset!,
-                            semanticLabel: symbol,
-                            errorBuilder: (_, _, _) => const _FallbackDot(),
-                          )
-                        : const _FallbackDot()),
-              ),
-              const SizedBox(width: GeniusWalletConsts.space6),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      symbol,
-                      style: GeniusWalletTypography.titleMd.copyWith(
-                        color: gw.textPrimary,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+    // Migrated to `GWHoverRow` with the three live lists on 2026-07-30 rather
+    // than left behind. This row only renders in the dev gallery today, and a
+    // gallery showing the OLD hover while every shipped list shows the new one
+    // would be the reference disagreeing with the thing it references.
+    return GWHoverRow(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: GeniusWalletConsts.space6,
+          vertical: GeniusWalletConsts.space4,
+        ),
+        child: Row(
+          children: [
+            SizedBox(
+              width: 40,
+              height: 40,
+              child:
+                  iconWidget ??
+                  (iconAsset != null
+                      ? Image.asset(
+                          iconAsset!,
+                          semanticLabel: symbol,
+                          errorBuilder: (_, _, _) => const _FallbackDot(),
+                        )
+                      : const _FallbackDot()),
+            ),
+            const SizedBox(width: GeniusWalletConsts.space6),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    symbol,
+                    style: GeniusWalletTypography.titleMd.copyWith(
+                      color: gw.textPrimary,
                     ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    name,
+                    style: GeniusWalletTypography.bodySm.copyWith(
+                      color: gw.textSecondary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            if (trailing != null)
+              trailing!
+            else if (balance != null)
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    balance!,
+                    style: GeniusWalletTypography.numericBody.copyWith(
+                      color: gw.textPrimary,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (subBalance != null)
                     Text(
-                      name,
+                      subBalance!,
                       style: GeniusWalletTypography.bodySm.copyWith(
                         color: gw.textSecondary,
                       ),
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                     ),
-                  ],
-                ),
+                ],
               ),
-              if (trailing != null)
-                trailing!
-              else if (balance != null)
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      balance!,
-                      style: GeniusWalletTypography.numericBody.copyWith(
-                        color: gw.textPrimary,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    if (subBalance != null)
-                      Text(
-                        subBalance!,
-                        style: GeniusWalletTypography.bodySm.copyWith(
-                          color: gw.textSecondary,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                  ],
-                ),
-            ],
-          ),
+          ],
         ),
       ),
     );

--- a/lib/components/coins/view/coin_card_row.dart
+++ b/lib/components/coins/view/coin_card_row.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:genius_wallet/components/effects/gw_hover_row.dart';
 import 'package:genius_wallet/hive/models/coin_gecko_market_data.dart';
 import 'package:genius_wallet/theme/genius_wallet_typography.dart';
 import 'package:genius_wallet/theme/gw_colors.dart';
@@ -55,70 +56,86 @@ class CoinCardRow extends StatelessWidget {
         ? "0.0000 $symbol"
         : "${WalletUtils.truncateToDecimals(balance.toString())} $symbol";
 
-    return ListTile(
+    // **The Assets rows had no hover at all, and the `ListTile` was why.**
+    // A `ListTile` draws its highlight on the nearest ANCESTOR `Material`, and
+    // in the dashboard's Assets panel that ancestor sits beneath the panel's
+    // own painted background - so the highlight was rendered and then covered
+    // by the very surface it was meant to light up. `GWHoverRow` carries its
+    // own transparent `Material` above the caller's paint, so the highlight
+    // cannot be buried, and it clips to `radiusMd` like the other two lists.
+    //
+    // The tile keeps its layout and loses only its tap: two overlapping ink
+    // responses on one row would double the highlight and fight for the
+    // pointer. `ListTile` renders no background of its own, so the highlight
+    // shows straight through it.
+    return GWHoverRow(
       onTap: onTap,
-      // horizontal 8 matches the Assets header inset so row content (icon +
-      // left text) and the trailing values share the header's left/right edge.
-      contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      leading: buildTokenIcon(iconPath: iconPath, size: 38),
-      title: Text(
-        name,
-        style: GeniusWalletTypography.titleMd.copyWith(color: gw.textPrimary),
-      ),
-      subtitle: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Flexible(
-            child: Text(
-              currencyFormatter.format(price),
+      semanticLabel: name,
+      child: ListTile(
+        // horizontal 8 matches the Assets header inset so row content (icon +
+        // left text) and the trailing values share the header's left/right
+        // edge.
+        contentPadding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        leading: buildTokenIcon(iconPath: iconPath, size: 38),
+        title: Text(
+          name,
+          style: GeniusWalletTypography.titleMd.copyWith(color: gw.textPrimary),
+        ),
+        subtitle: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Flexible(
+              child: Text(
+                currencyFormatter.format(price),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: GeniusWalletTypography.bodySm.copyWith(
+                  color: gw.textSecondary,
+                ),
+              ),
+            ),
+            const SizedBox(width: 6),
+            // Filled 24h% chip — market data, always full strength.
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: changeColor.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                '${pct >= 0 ? '+' : ''}${pct.toStringAsFixed(2)}%',
+                style: GeniusWalletTypography.labelMd.copyWith(
+                  color: changeColor,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ),
+        trailing: Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              currencyFormatter.format(fiatValue),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: GeniusWalletTypography.numericBody.copyWith(
+                fontWeight: FontWeight.bold,
+                color: noBalance ? gw.textPrimary38 : gw.textPrimary,
+              ),
+            ),
+            Text(
+              amountText,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: GeniusWalletTypography.bodySm.copyWith(
-                color: gw.textSecondary,
+                color: noBalance ? gw.textPrimary38 : gw.textSecondary,
               ),
             ),
-          ),
-          const SizedBox(width: 6),
-          // Filled 24h% chip — market data, always full strength.
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: changeColor.withValues(alpha: 0.15),
-              borderRadius: BorderRadius.circular(8),
-            ),
-            child: Text(
-              '${pct >= 0 ? '+' : ''}${pct.toStringAsFixed(2)}%',
-              style: GeniusWalletTypography.labelMd.copyWith(
-                color: changeColor,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
-        ],
-      ),
-      trailing: Column(
-        crossAxisAlignment: CrossAxisAlignment.end,
-        mainAxisAlignment: MainAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            currencyFormatter.format(fiatValue),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: GeniusWalletTypography.numericBody.copyWith(
-              fontWeight: FontWeight.bold,
-              color: noBalance ? gw.textPrimary38 : gw.textPrimary,
-            ),
-          ),
-          Text(
-            amountText,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: GeniusWalletTypography.bodySm.copyWith(
-              color: noBalance ? gw.textPrimary38 : gw.textSecondary,
-            ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/components/effects/gw_hover_row.dart
+++ b/lib/components/effects/gw_hover_row.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:genius_wallet/theme/genius_wallet_consts.dart';
+import 'package:genius_wallet/theme/gw_colors.dart';
+
+/// How far a hovered row lifts off its own background.
+///
+/// 6% of the appearance's foreground, which is **one surface step**: measured
+/// against a card (`surfaceElevated` #0C0E14) it lands at 1.135, and
+/// `surfaceMenu` - the fill the chip hover already lifts onto - is 1.108 on the
+/// same background. So a hovered row and a hovered chip read as the same
+/// gesture at the same weight, without the row needing a second hover language.
+///
+/// It is deliberately louder than Flutter's stock `ThemeData.hoverColor`, which
+/// is 4% (`0x0AFFFFFF`) and measures 1.086 - the value every row in this app
+/// was inheriting, and the reason two of the three lists read as having no
+/// hover at all.
+const double kGWRowHoverAlpha = 0.06;
+
+/// The one hover treatment for a full-width tappable ROW: a rounded highlight
+/// across the whole row, a click cursor, and the framework's press feedback.
+///
+/// **Why rows get their own component rather than the "lift chip".** The hover
+/// design system's standard response is D - rise onto `surfaceElevated`, take
+/// the card shadow, lift 1px - and that is right for something that sits in a
+/// track and can be pressed, like a nav tab or a timeframe chip. A row in a
+/// list is a different affordance: it spans the panel, it has neighbours
+/// directly above and below, and lifting it would make a list flicker as a
+/// whole card every time the pointer crossed it. Rows express the same system
+/// as a rounded highlight instead - the same reason `gw_view_all_link.dart`
+/// keeps a gradient underline rather than being boxed into a chip.
+///
+/// **What this fixes, all three of which the 2026-07-30 walk found together:**
+///
+///  1. **Assets had no hover at all.** Its row is a `ListTile`, whose ink is
+///     drawn on the nearest ancestor `Material`. On the dashboard that ancestor
+///     sits BENEATH the panel's own painted background, so the highlight was
+///     rendered and then covered. The local `Material` here is above every
+///     caller's background by construction, so the highlight cannot be buried.
+///  2. **Markets had square corners.** Its row is a bare `InkWell` with no
+///     `borderRadius`, so the highlight painted as a full-bleed rectangle while
+///     Transactions - the only one that passed `radiusMd` - painted rounded.
+///  3. **All three inherited the theme's hover colour** rather than stating
+///     one, so the strength of the feedback was whatever `ThemeData` happened
+///     to default to.
+///
+/// The child arrives ALREADY PADDED. This owns the highlight, the radius, the
+/// cursor and the tap; it does not own spacing, because its three callers have
+/// three different row anatomies and a padding parameter here would just be
+/// each of them passing its own value back.
+class GWHoverRow extends StatelessWidget {
+  const GWHoverRow({
+    super.key,
+    required this.child,
+    this.onTap,
+    this.radius = GeniusWalletConsts.radiusMd,
+    this.semanticLabel,
+  });
+
+  final Widget child;
+
+  /// A null [onTap] disables the highlight along with the tap - a row that does
+  /// nothing must not claim it does.
+  final VoidCallback? onTap;
+
+  /// Rounded by default, at the same `radiusMd` the Transactions list already
+  /// used and the one Jakub picked as the reference on 2026-07-30.
+  final double radius;
+
+  final String? semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    // Fail-soft read: registers the InheritedWidget dependency that forces this
+    // subtree to rebuild on a live appearance toggle (04-04 discipline).
+    final gw = Theme.of(context).extension<GWColors>() ?? GWColors.dark();
+
+    // Derived from `textPrimary` rather than a new palette field: that token is
+    // already white on dark and ink on light, which is exactly what a
+    // foreground-tinted overlay needs, and a translucent overlay composites
+    // correctly onto whatever the caller sits on. A fixed hover FILL could not
+    // - these rows live on `surfaceElevated` in the dashboard panels and on
+    // `surfaceBase` on the Markets page.
+    final Color hover = gw.textPrimary.withValues(alpha: kGWRowHoverAlpha);
+
+    final Widget row = Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(radius),
+        onTap: onTap,
+        hoverColor: hover,
+        mouseCursor: onTap == null
+            ? SystemMouseCursors.basic
+            : SystemMouseCursors.click,
+        child: child,
+      ),
+    );
+
+    if (semanticLabel == null) {
+      return row;
+    }
+    return Semantics(button: onTap != null, label: semanticLabel, child: row);
+  }
+}

--- a/lib/dashboard/chart/markets_hero_card.dart
+++ b/lib/dashboard/chart/markets_hero_card.dart
@@ -1,6 +1,7 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:genius_wallet/chart/chart_axis.dart';
+import 'package:genius_wallet/chart/crypto_live_chart.dart' show chartYBounds;
 import 'package:genius_wallet/components/cards/gw_stat_tile.dart';
 import 'package:genius_wallet/hive/models/coin_gecko_coin.dart';
 import 'package:genius_wallet/hive/models/coin_gecko_market_data.dart';
@@ -15,26 +16,43 @@ import 'package:genius_wallet/utils/breakpoints.dart';
 import 'package:genius_wallet/utils/image_utils.dart';
 import 'package:intl/intl.dart';
 
-/// The hero chart's own height.
+/// The hero chart's height in the WIDE (`IntrinsicHeight` row) layout.
 ///
-/// **Still 180 — 078-S6's "grow to 253 for free" hypothesis was FALSIFIED by
-/// `test/dashboard/markets_hero_height_test.dart`, not shipped.** The plan's
-/// derivation (left column 301 = 46 icon + 20 + 48 price + 16 + 24 pill + 24
-/// + 1 rule + 24 + 39 stat + 20 + 39 stat; right column 48 + chart; `Spacer`
-/// at `:168` absorbing the 73px difference) predicted the WIDE card would be
-/// the exact same height at 180 and at 253. Measured instead of trusted: the
-/// test recorded the real card height at the shipped 180 first
-/// (`tester.getSize`, not arithmetic), then flipped this constant to 253 and
-/// re-ran the SAME assertion — and the wide card grew by 73px, the full
-/// amount the `Spacer` was supposed to be absorbing. The `IntrinsicHeight`
-/// row's actual cross-axis intrinsic-height computation with a flex-child
-/// `Spacer` does not zero out the way the derivation assumed.
+/// **253, and the "falsification" that kept it at 180 was itself wrong.**
+/// 078-S6 derived that growing this from 180 to 253 costs the wide card no
+/// height, because the `Spacer` at [_MarketsHeroCardState.build] absorbs the
+/// difference inside an `IntrinsicHeight` row driven by the taller LEFT column
+/// (301 = 46 icon + 20 + 48 price + 16 + 24 pill + 24 + 1 rule + 24 + 39 stat
+/// + 20 + 39 stat). `markets_hero_height_test.dart` appeared to refute that:
+/// it measured 619.0 at 180 and 692.0 at 253, the full 73px of growth, and the
+/// hypothesis was recorded as dead.
 ///
-/// Per this task's own instruction — "if the wide-layout card grows, STOP
-/// and report it; do not accept a taller card and do not adjust the constant
-/// to match" — this stays at 180 pending Jakub's decision. See
-/// `260729-gt4-SUMMARY.md` for the full writeup.
-const double kMarketsHeroChartHeight = 180;
+/// **That test never reached the wide layout.** Its host wraps the card in
+/// `SizedBox(width: 1200)` and its comments claim the width exercises the
+/// `IntrinsicHeight` branch - but it never set the test surface, which
+/// defaults to 800x600, so the `SizedBox` was clamped and the card rendered
+/// **stacked**. The stacked branch passes `fill: false`, which omits the
+/// `Spacer` and the `IntrinsicHeight` entirely, so of course the card grew by
+/// exactly the chart's delta. It was measuring the one layout where the claim
+/// was never made.
+///
+/// Re-measured 2026-07-30 with `tester.view.physicalSize` actually set to
+/// 1400x1000: the `IntrinsicHeight` row reports **301.0** - the derivation to
+/// the pixel - and the card holds **367.0** at both 180 and 253, with the
+/// chart's lower edge landing on the stat row at y=334 either way. The
+/// original arithmetic was right; the instrument was wrong.
+const double kMarketsHeroChartHeight = 253;
+
+/// The height used when the card STACKS (below `GeniusBreakpoints.medium`).
+///
+/// Stays at 180 deliberately. The wide layout's 73px is free because a `Spacer`
+/// gives it back; the stacked layout has neither `Spacer` nor
+/// `IntrinsicHeight`, so every pixel added here is a pixel the card grows on
+/// the narrowest screens. 180 is also below `kChartFrameMinHeight`, so the
+/// stacked hero keeps the axis-free chart - the same runtime A/B rule the coin
+/// page already follows, arrived at by measuring the box rather than by
+/// flagging the surface.
+const double kMarketsHeroChartHeightStacked = 180;
 
 /// Markets hero (sketch 103 · H1 "Refined split"): identity + oversized price
 /// + a 2×2 stat block on the left, the 7d chart with a timeframe selector on
@@ -188,7 +206,9 @@ class _MarketsHeroCardState extends State<MarketsHeroCard> {
           const SizedBox(height: GeniusWalletConsts.space8),
           if (fill) const Spacer(),
           SizedBox(
-            height: kMarketsHeroChartHeight,
+            height: fill
+                ? kMarketsHeroChartHeight
+                : kMarketsHeroChartHeightStacked,
             child: _HeroChart(sparkline: data.sparkline),
           ),
         ],
@@ -309,9 +329,23 @@ class _ChangePill extends StatelessWidget {
   }
 }
 
-/// 7d sparkline drawn large as a brand-gradient area chart. No axes, no touch
-/// (a static hero backdrop). Falls back to a quiet placeholder when the
-/// sparkline is missing.
+/// The 7d hero chart, on the SAME runtime A/B rule as the coin page: scheme B's
+/// trading frame when the box it is handed clears [kChartFrameMinHeight],
+/// today's axis-free chart below it.
+///
+/// Until 2026-07-30 this surface only ever got 078's colour rules - trend
+/// colour and the `borderControl` contrast fix - because it sat at 180px and
+/// the frame needs 220. It is 253 in the wide layout now (see
+/// [kMarketsHeroChartHeight] for why that is free), so the frame applies where
+/// there is room and does not where there is not.
+///
+/// **One widget with a `framed` bool rather than the two `StatelessWidget`s
+/// `crypto_live_chart.dart` splits into.** That file's split earns itself: its
+/// two schemes differ in their Y-window handling (`chartBandedBounds`) and in
+/// carrying `_HighLowPlate`s, so they are genuinely two charts. Here the line,
+/// the fill, the touch behaviour and the tooltip are byte-identical between
+/// branches and only the frame parts differ, so two widgets would be one widget
+/// copied twice.
 class _HeroChart extends StatelessWidget {
   final List<double>? sparkline;
   const _HeroChart({required this.sparkline});
@@ -364,104 +398,220 @@ class _HeroChart extends StatelessWidget {
     DateTime timeAt(double x) =>
         now.subtract(Duration(milliseconds: ((n - 1 - x) * stepMs).round()));
 
-    return LineChart(
-      LineChartData(
-        lineBarsData: [
-          LineChartBarData(
-            spots: spots,
-            isCurved: true,
-            color: trend,
-            barWidth: 2.5,
-            dotData: const FlDotData(show: false),
-            belowBarData: BarAreaData(
-              show: true,
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                colors: [
-                  trend.withValues(alpha: 0.18),
-                  trend.withValues(alpha: 0.0),
-                ],
-                // Same non-zero-baseline honesty as the main chart
-                // (`crypto_live_chart.dart`): this widget sets no `minY`/
-                // `maxY`, so an edge-to-edge fill would otherwise run to a
-                // floor the scale never claims.
-                stops: const [0.0, kChartFillFadeStop],
+    return LayoutBuilder(
+      builder: (context, c) {
+        // Measured off the box actually handed to the plot, never off a
+        // per-surface flag — 078-S4's whole point. `c.maxHeight` is the
+        // `SizedBox` in `buildRight`, so the stacked layout's 180 lands below
+        // the threshold and the wide layout's 253 above it.
+        final bool framed = chartUsesFrame(c.maxHeight);
+        final (yLo, yHi) = chartYBounds(spots);
+
+        // Grid lines and right-axis labels BOTH iterate from the axis baseline
+        // by `interval`, so handing them the SAME step is what makes every
+        // label land on a gridline by construction.
+        final (_, step) = chartTickStep(
+          yLo,
+          yHi,
+          chartYTickCount(c.maxHeight - kChartTimeRowHeight),
+        );
+
+        final chart = LineChart(
+          LineChartData(
+            minY: framed ? yLo : null,
+            maxY: framed ? yHi : null,
+            gridData: FlGridData(
+              show: framed,
+              drawVerticalLine: false,
+              horizontalInterval: step,
+              getDrawingHorizontalLine: (_) => FlLine(
+                color: gw.borderSubtle.withValues(alpha: 0.06),
+                strokeWidth: 1,
+              ),
+            ),
+            titlesData: FlTitlesData(
+              show: framed,
+              leftTitles: const AxisTitles(
+                sideTitles: SideTitles(showTitles: false),
+              ),
+              topTitles: const AxisTitles(
+                sideTitles: SideTitles(showTitles: false),
+              ),
+              bottomTitles: const AxisTitles(
+                sideTitles: SideTitles(showTitles: false),
+              ),
+              rightTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: framed,
+                  reservedSize: kChartAxisGutter,
+                  interval: step,
+                  // MUST stay false, or fl_chart also prints the raw padded
+                  // min/max, which are not on the nice-number ladder.
+                  minIncluded: false,
+                  maxIncluded: false,
+                  getTitlesWidget: (value, meta) => SideTitleWidget(
+                    meta: meta,
+                    space: 8,
+                    child: Text(
+                      axisMoneyLabel(value, step),
+                      style: TextStyle(
+                        fontSize: 11,
+                        color: gw.textSecondary,
+                        fontFeatures: const [FontFeature.tabularFigures()],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            lineBarsData: [
+              LineChartBarData(
+                spots: spots,
+                isCurved: true,
+                color: trend,
+                barWidth: 2.5,
+                dotData: const FlDotData(show: false),
+                belowBarData: BarAreaData(
+                  show: true,
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      trend.withValues(alpha: 0.18),
+                      trend.withValues(alpha: 0.0),
+                    ],
+                    // Same non-zero-baseline honesty as the main chart
+                    // (`crypto_live_chart.dart`): the scale never claims a zero
+                    // floor, so an edge-to-edge fill would run to one it does not
+                    // have. Unchanged by the frame - `kChartFillFadeStop` is
+                    // derived from `belowBarLargestRect`, which is the highest
+                    // spot to the plot floor either way.
+                    stops: const [0.0, kChartFillFadeStop],
+                  ),
+                ),
+              ),
+            ],
+            borderData: FlBorderData(show: false),
+            lineTouchData: LineTouchData(
+              enabled: true,
+              handleBuiltInTouches: true,
+              getTouchedSpotIndicator: (barData, spotIndexes) {
+                return spotIndexes.map((index) {
+                  return TouchedSpotIndicatorData(
+                    // borderControl (3.30:1 dark / 3.10:1 light) clears WCAG
+                    // 1.4.11's 3:1 gate; borderStrong (2.10:1) did not — same
+                    // token, same reason as the main chart's crosshair.
+                    FlLine(color: gw.borderControl, strokeWidth: 1),
+                    FlDotData(
+                      getDotPainter: (spot, percent, bar, i) =>
+                          FlDotCirclePainter(
+                            radius: 4,
+                            color: trend,
+                            strokeWidth: 3,
+                            strokeColor: trend.withValues(alpha: 0.26),
+                          ),
+                    ),
+                  );
+                }).toList();
+              },
+              touchTooltipData: LineTouchTooltipData(
+                fitInsideHorizontally: true,
+                fitInsideVertically: true,
+                tooltipBorderRadius: BorderRadius.circular(10),
+                tooltipBorder: BorderSide(color: gw.borderSubtle),
+                getTooltipColor: (touchedSpot) => gw.surfaceElevated,
+                getTooltipItems: (touchedSpots) {
+                  return touchedSpots.map((spot) {
+                    final double pct = first > 0
+                        ? ((spot.y - first) / first) * 100
+                        : 0;
+                    final Color pctColor = pct >= 0
+                        ? gw.statusSuccess
+                        : gw.statusError;
+                    final int decimals = spot.y >= 1 ? 2 : 6;
+                    return LineTooltipItem(
+                      '${DateFormat('MMM d, h:mm a').format(timeAt(spot.x))}\n',
+                      GeniusWalletTypography.labelMd.copyWith(
+                        color: gw.textSecondary,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      children: [
+                        TextSpan(
+                          text: NumberFormat.currency(
+                            symbol: '\$',
+                            decimalDigits: decimals,
+                          ).format(spot.y),
+                          style: GeniusWalletTypography.numericBody.copyWith(
+                            color: gw.textPrimary,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        TextSpan(
+                          text:
+                              '  ${pct >= 0 ? '+' : ''}${pct.toStringAsFixed(2)}%',
+                          style: GeniusWalletTypography.labelMd.copyWith(
+                            color: pctColor,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ],
+                    );
+                  }).toList();
+                },
               ),
             ),
           ),
-        ],
-        titlesData: const FlTitlesData(show: false),
-        gridData: const FlGridData(show: false),
-        borderData: FlBorderData(show: false),
-        lineTouchData: LineTouchData(
-          enabled: true,
-          handleBuiltInTouches: true,
-          getTouchedSpotIndicator: (barData, spotIndexes) {
-            return spotIndexes.map((index) {
-              return TouchedSpotIndicatorData(
-                // borderControl (3.30:1 dark / 3.10:1 light) clears WCAG
-                // 1.4.11's 3:1 gate; borderStrong (2.10:1) did not — same
-                // token, same reason as the main chart's crosshair.
-                FlLine(color: gw.borderControl, strokeWidth: 1),
-                FlDotData(
-                  getDotPainter: (spot, percent, bar, i) => FlDotCirclePainter(
-                    radius: 4,
-                    color: trend,
-                    strokeWidth: 3,
-                    strokeColor: trend.withValues(alpha: 0.26),
-                  ),
+        );
+
+        if (!framed) {
+          return chart;
+        }
+
+        // A plain Row of Texts, NOT fl_chart's bottom titles — fl_chart anchors
+        // its x intervals to `baselineX`, which cannot be lined up with the
+        // sparkline's index positions without fighting the library. Same
+        // reasoning, same constants as `crypto_live_chart.dart`'s frame.
+        //
+        // The labels are DATES, not times. The coin chart prints clock times
+        // because its window can be an hour; this series is always the 7d
+        // `sparkline`, where six identical `h:mm a` labels would be the exact
+        // class of lie the timeframe work is removing.
+        return Column(
+          children: [
+            Expanded(child: chart),
+            SizedBox(
+              height: kChartTimeRowHeight,
+              child: Padding(
+                padding: const EdgeInsets.only(right: kChartAxisGutter),
+                child: LayoutBuilder(
+                  builder: (context, rowConstraints) {
+                    final int count = chartXLabelCount(
+                      plotWidth: rowConstraints.maxWidth,
+                      sampleCount: spots.length,
+                    );
+                    return Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: List.generate(count, (b) {
+                        final int ix = count > 1
+                            ? ((b / (count - 1)) * (spots.length - 1)).round()
+                            : 0;
+                        return Text(
+                          DateFormat('MMM d').format(timeAt(spots[ix].x)),
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: gw.textSecondary,
+                            fontFeatures: const [FontFeature.tabularFigures()],
+                          ),
+                        );
+                      }),
+                    );
+                  },
                 ),
-              );
-            }).toList();
-          },
-          touchTooltipData: LineTouchTooltipData(
-            fitInsideHorizontally: true,
-            fitInsideVertically: true,
-            tooltipBorderRadius: BorderRadius.circular(10),
-            tooltipBorder: BorderSide(color: gw.borderSubtle),
-            getTooltipColor: (touchedSpot) => gw.surfaceElevated,
-            getTooltipItems: (touchedSpots) {
-              return touchedSpots.map((spot) {
-                final double pct = first > 0
-                    ? ((spot.y - first) / first) * 100
-                    : 0;
-                final Color pctColor = pct >= 0
-                    ? gw.statusSuccess
-                    : gw.statusError;
-                final int decimals = spot.y >= 1 ? 2 : 6;
-                return LineTooltipItem(
-                  '${DateFormat('MMM d, h:mm a').format(timeAt(spot.x))}\n',
-                  GeniusWalletTypography.labelMd.copyWith(
-                    color: gw.textSecondary,
-                    fontWeight: FontWeight.w500,
-                  ),
-                  children: [
-                    TextSpan(
-                      text: NumberFormat.currency(
-                        symbol: '\$',
-                        decimalDigits: decimals,
-                      ).format(spot.y),
-                      style: GeniusWalletTypography.numericBody.copyWith(
-                        color: gw.textPrimary,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    TextSpan(
-                      text:
-                          '  ${pct >= 0 ? '+' : ''}${pct.toStringAsFixed(2)}%',
-                      style: GeniusWalletTypography.labelMd.copyWith(
-                        color: pctColor,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ],
-                );
-              }).toList();
-            },
-          ),
-        ),
-      ),
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/dashboard/chart/markets_table.dart
+++ b/lib/dashboard/chart/markets_table.dart
@@ -1,6 +1,7 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:genius_wallet/components/cards/gw_kicker.dart';
+import 'package:genius_wallet/components/effects/gw_hover_row.dart';
 import 'package:genius_wallet/dashboard/chart/markets_sort.dart';
 import 'package:genius_wallet/hive/models/coin_gecko_coin.dart';
 import 'package:genius_wallet/hive/models/coin_gecko_market_data.dart';
@@ -207,7 +208,16 @@ class _MarketsTableState extends State<MarketsTable> {
     final up = data.priceChangePercentage24h >= 0;
     final changeColor = up ? gw.statusSuccess : gw.statusError;
 
-    return InkWell(
+    // Was a bare `InkWell` with no `borderRadius`, which is the whole of the
+    // "market ma proste rogi" finding on 2026-07-30: Material clips a
+    // highlight to the radius it is given, and given none it paints the row as
+    // a full-bleed rectangle while the Transactions list painted rounded.
+    //
+    // The bottom hairline stays full-width under the rounded highlight on
+    // purpose - it is the table's row RULE, not the row's edge, and a divider
+    // that stopped short of the column edges would stop separating the columns
+    // it is there to separate.
+    return GWHoverRow(
       onTap: () => widget.onTapRow(row),
       child: Container(
         padding: const EdgeInsets.symmetric(

--- a/lib/dashboard/home/widgets/transaction_displays.dart
+++ b/lib/dashboard/home/widgets/transaction_displays.dart
@@ -5,6 +5,7 @@ import 'package:genius_wallet/components/bottom_drawer/responsive_drawer.dart';
 import 'package:genius_wallet/components/buttons/gw_button.dart';
 import 'package:genius_wallet/components/cards/gw_detail_grid.dart';
 import 'package:genius_wallet/components/cards/gw_kicker.dart';
+import 'package:genius_wallet/components/effects/gw_hover_row.dart';
 import 'package:genius_wallet/components/scaffold/scaffold_helper.dart';
 import 'package:genius_wallet/dashboard/home/widgets/transaction_badge.dart';
 import 'package:genius_wallet/dashboard/home/widgets/transaction_utils.dart';
@@ -290,135 +291,138 @@ class TransactionRow extends StatelessWidget {
       ],
     );
 
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(GeniusWalletConsts.radiusMd),
-        onTap: onTap,
-        mouseCursor: SystemMouseCursors.click,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: GeniusWalletConsts.space6,
-            vertical: GeniusWalletConsts.space4,
-          ),
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              // BOOLEAN from constraints, never a per-frame dimension — the
-              // freeze rule (37639d5) bans continuous sizes, not breakpoints.
-              final bool wide = constraints.maxWidth >= _wideRowThreshold;
-              return Row(
-                children: [
-                  // Time leads the row: it is fixed-width and tabular, so the
-                  // token icons line up in a straight column behind it and the
-                  // eye can scan either "when" or "what" down a single edge.
-                  SizedBox(
-                    width: 44,
-                    child: Text(
-                      content.time,
-                      textAlign: TextAlign.left,
-                      maxLines: 1,
-                      style: GeniusWalletTypography.numericBody.copyWith(
-                        fontSize: 13,
-                        fontWeight: FontWeight.w400,
-                        // Not the sketch's --text-primary-38 (~3.0:1): the
-                        // timestamp is meaningful text and must clear AA.
-                        color: gw.textSecondary,
-                      ),
+    // The hover treatment moved into `GWHoverRow` on 2026-07-30 and this row is
+    // where it came from: of the app's three tappable lists, this was the only
+    // one that carried its own transparent `Material` and passed a `radiusMd`,
+    // which is why it was the only one whose highlight was both visible and
+    // rounded. Nothing here changes shape - the component states the hover
+    // colour explicitly instead of inheriting `ThemeData`'s 4% default, so the
+    // highlight is one step stronger and identical across all three lists.
+    return GWHoverRow(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: GeniusWalletConsts.space6,
+          vertical: GeniusWalletConsts.space4,
+        ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            // BOOLEAN from constraints, never a per-frame dimension — the
+            // freeze rule (37639d5) bans continuous sizes, not breakpoints.
+            final bool wide = constraints.maxWidth >= _wideRowThreshold;
+            return Row(
+              children: [
+                // Time leads the row: it is fixed-width and tabular, so the
+                // token icons line up in a straight column behind it and the
+                // eye can scan either "when" or "what" down a single edge.
+                SizedBox(
+                  width: 44,
+                  child: Text(
+                    content.time,
+                    textAlign: TextAlign.left,
+                    maxLines: 1,
+                    style: GeniusWalletTypography.numericBody.copyWith(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w400,
+                      // Not the sketch's --text-primary-38 (~3.0:1): the
+                      // timestamp is meaningful text and must clear AA.
+                      color: gw.textSecondary,
                     ),
                   ),
-                  const SizedBox(width: GeniusWalletConsts.space6),
-                  _identity(content, gw, size: 40),
-                  const SizedBox(width: GeniusWalletConsts.space6),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Row(
-                          children: [
-                            // Token-first (010-A): the asset is the headline, the
-                            // action a quiet chip beside it.
-                            Flexible(
+                ),
+                const SizedBox(width: GeniusWalletConsts.space6),
+                _identity(content, gw, size: 40),
+                const SizedBox(width: GeniusWalletConsts.space6),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Row(
+                        children: [
+                          // Token-first (010-A): the asset is the headline, the
+                          // action a quiet chip beside it.
+                          Flexible(
+                            child: Text(
+                              content.title,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: GeniusWalletTypography.titleMd.copyWith(
+                                fontWeight: FontWeight.w600,
+                                color: gw.textPrimary,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: GeniusWalletConsts.space4),
+                          Flexible(
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: GeniusWalletConsts.space2,
+                                vertical: 2,
+                              ),
+                              decoration: BoxDecoration(
+                                color: gw.surfaceMenu,
+                                borderRadius: BorderRadius.circular(
+                                  GeniusWalletConsts.radiusXs,
+                                ),
+                              ),
                               child: Text(
-                                content.title,
+                                content.action,
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
-                                style: GeniusWalletTypography.titleMd.copyWith(
-                                  fontWeight: FontWeight.w600,
-                                  color: gw.textPrimary,
+                                style: GeniusWalletTypography.labelMd.copyWith(
+                                  color: gw.textSecondary,
                                 ),
                               ),
                             ),
-                            const SizedBox(width: GeniusWalletConsts.space4),
-                            Flexible(
-                              child: Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: GeniusWalletConsts.space2,
-                                  vertical: 2,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: gw.surfaceMenu,
-                                  borderRadius: BorderRadius.circular(
-                                    GeniusWalletConsts.radiusXs,
-                                  ),
-                                ),
-                                child: Text(
-                                  content.action,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: GeniusWalletTypography.labelMd
-                                      .copyWith(color: gw.textSecondary),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: GeniusWalletConsts.space2),
-                        Text(
-                          // On the wide page the Status pill carries the status, so
-                          // the subtitle drops the ` · Failed` suffix (no double
-                          // statement). On the panel it keeps it — no pill there.
-                          wide ? content.subtitleBase : content.subtitle,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: GeniusWalletTypography.bodySm.copyWith(
-                            color: gw.textSecondary,
                           ),
+                        ],
+                      ),
+                      const SizedBox(height: GeniusWalletConsts.space2),
+                      Text(
+                        // On the wide page the Status pill carries the status, so
+                        // the subtitle drops the ` · Failed` suffix (no double
+                        // statement). On the panel it keeps it — no pill there.
+                        wide ? content.subtitleBase : content.subtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: GeniusWalletTypography.bodySm.copyWith(
+                          color: gw.textSecondary,
                         ),
-                      ],
-                    ),
+                      ),
+                    ],
                   ),
-                  // Right side.
-                  //
-                  // WIDE page (sketch 030-A2): a Status pill, then a fixed
-                  // `space6` (12px, the same gap as time↔coin) gap, then a
-                  // fixed-width amount column. Because the amount column is a fixed
-                  // width sitting flush right and `Expanded` above absorbs all the
-                  // slack, the pill's right edge lands on ONE vertical line a
-                  // constant space6 off the amount — "every status respects one
-                  // place", whatever the label's width.
-                  //
-                  // NARROW panel: the amount takes an `Expanded` (tight) so it
-                  // right-aligns to the card edge and ellipsises when the row is
-                  // genuinely narrow (the 320px case) instead of overflowing; no
-                  // pill — the status stays folded into the subtitle there.
-                  //
-                  // Neither branch derives a dimension from constraints; the split
-                  // is one boolean and the amount width is a constant (37639d5).
-                  if (wide) ...[
-                    const SizedBox(width: GeniusWalletConsts.space6),
-                    _statusPill(content.status, gw),
-                    const SizedBox(width: GeniusWalletConsts.space6),
-                    SizedBox(width: _wideAmountWidth, child: amountColumn),
-                  ] else ...[
-                    const SizedBox(width: GeniusWalletConsts.space4),
-                    Expanded(child: amountColumn),
-                  ],
+                ),
+                // Right side.
+                //
+                // WIDE page (sketch 030-A2): a Status pill, then a fixed
+                // `space6` (12px, the same gap as time↔coin) gap, then a
+                // fixed-width amount column. Because the amount column is a fixed
+                // width sitting flush right and `Expanded` above absorbs all the
+                // slack, the pill's right edge lands on ONE vertical line a
+                // constant space6 off the amount — "every status respects one
+                // place", whatever the label's width.
+                //
+                // NARROW panel: the amount takes an `Expanded` (tight) so it
+                // right-aligns to the card edge and ellipsises when the row is
+                // genuinely narrow (the 320px case) instead of overflowing; no
+                // pill — the status stays folded into the subtitle there.
+                //
+                // Neither branch derives a dimension from constraints; the split
+                // is one boolean and the amount width is a constant (37639d5).
+                if (wide) ...[
+                  const SizedBox(width: GeniusWalletConsts.space6),
+                  _statusPill(content.status, gw),
+                  const SizedBox(width: GeniusWalletConsts.space6),
+                  SizedBox(width: _wideAmountWidth, child: amountColumn),
+                ] else ...[
+                  const SizedBox(width: GeniusWalletConsts.space4),
+                  Expanded(child: amountColumn),
                 ],
-              );
-            },
-          ),
+              ],
+            );
+          },
         ),
       ),
     );

--- a/lib/tokens/token_info_screen.dart
+++ b/lib/tokens/token_info_screen.dart
@@ -499,16 +499,41 @@ class TokenInfoScreen extends StatelessWidget {
     // two buttons is the whole change - it clears 2.5.8 (AA) and fails 2.5.5
     // (AAA), which is the decision, not a tweak.
     //
-    // The accepted cost: at rest the icons have no boundary, and the hover
-    // circle is the only edge. That is fine under 1.4.11 - a control's edge
-    // must clear 3:1 only when the EDGE is what identifies the control, and
-    // here the glyph is, at 15.8:1 dark / 16.1:1 light. Same argument
-    // `GWSelectRow` recorded for its check mark.
+    // **That accepted cost was cashed in on 2026-07-29 and is now paid off.**
+    // The paragraph above used to end here saying the icons have no boundary at
+    // rest and that this is fine under 1.4.11, because the GLYPH identifies the
+    // control, not its edge. The standards argument still holds. What did not
+    // hold is the product one: the walk found both actions by eye as "nie halo"
+    // - two bare glyphs floating beside a 26px coin name, reading as decoration
+    // rather than buttons. Sketch 164-C adds the boundary back.
+    //
+    // **It adds it at 32px inside the 48px target, and that split is the whole
+    // point.** Switching to `GWButtonVariant.icon` was the obvious move and it
+    // would have reversed the 2026-07-28 decision recorded above - Jakub's
+    // *"te ikony powinny być wysokości tytułu, nie większe"* - because that
+    // variant paints its box at the button's full 48. So the TARGET stays 48
+    // (2.5.5 AAA, kept on Jakub's explicit call) and the PAINTED box is 32,
+    // which is the title's own height. Nothing is reversed.
+    //
+    // **The edge carries it, not the fill**, and that is measured rather than
+    // chosen: this row sits on the PAGE (`surfaceBase` #0B0D12), and
+    // `variant: icon`'s own `surfaceElevated` fill is #0C0E14 - **1.01:1**
+    // against it, i.e. not a box at all. `surfaceMenu` is 1.12:1, a lift and no
+    // more. Only `borderControl` draws, at **3.28:1**, and that is precisely
+    // the token's documented job: *"the edge of a CONTROL whose fill cannot
+    // identify it"*.
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         GWButton.icon(
-          icon: const Icon(Icons.qr_code_2),
+          // `call_received` replaces `Icons.qr_code_2` (Jakub, 2026-07-29).
+          // The old glyph is a finder-square-plus-data-field matrix - roughly
+          // twenty sub-3px shapes inside a 20px box - which rasterised into
+          // noise at this size. Two strokes resolve at any size. The cost is
+          // named, not hidden: the matrix said "there is a code to scan" and
+          // the drawer this opens IS a QR code, so the arrow trades a little
+          // specificity for legibility.
+          icon: const _ActionGlyph(Icons.call_received),
           variant: GWButtonVariant.ghost,
           size: GWButtonSize.md,
           tooltip: 'Receive',
@@ -541,7 +566,9 @@ class TokenInfoScreen extends StatelessWidget {
           ),
         ),
         GWButton.icon(
-          icon: const Icon(Icons.swap_horiz),
+          // `swap_horiz` kept verbatim (Jakub, 2026-07-29): it reads fine at
+          // 20px, so only the container and the tint change here.
+          icon: const _ActionGlyph(Icons.swap_horiz),
           variant: GWButtonVariant.ghost,
           size: GWButtonSize.md,
           tooltip: 'Swap',
@@ -581,7 +608,14 @@ class TokenInfoScreen extends StatelessWidget {
         ),
         if (isGnusBridgeEnabled)
           GWButton.icon(
-            icon: const Icon(Icons.alt_route),
+            // Bridge was not in the 164 brief, but it stands in the same row on
+            // GNUS-enabled coins. Leaving it bare next to two bounded siblings
+            // would read as a broken third button rather than a restrained one,
+            // so it takes the same treatment. Flagged rather than assumed.
+            icon: _ActionGlyph(
+              Icons.alt_route,
+              enabled: selectedCoin?.balance != 0,
+            ),
             variant: GWButtonVariant.ghost,
             size: GWButtonSize.md,
             tooltip: selectedCoin?.balance == 0
@@ -646,27 +680,32 @@ class CoinConvertCard extends StatefulWidget {
 
 class CoinConvertCardState extends State<CoinConvertCard> {
   late TextEditingController _tokenAmountController;
-  late TextEditingController _tokenPriceController;
 
   double _totalValue = 0;
 
   @override
   void initState() {
     super.initState();
-    _tokenPriceController = TextEditingController(
-      text: widget.tokenPrice.toString(),
-    );
     _tokenAmountController = TextEditingController(text: "1");
     _calculateTotalValue();
   }
 
+  @override
+  void dispose() {
+    _tokenAmountController.dispose();
+    super.dispose();
+  }
+
+  /// Reads the price straight off the widget. It used to be parsed back out of
+  /// `_tokenPriceController.text`, which only existed because the display was
+  /// an input - a `double` stringified into a controller and re-parsed on every
+  /// keystroke. 164-A made the display a fact, so the round trip went with it.
   void _calculateTotalValue() {
     final double tokenAmount =
         double.tryParse(_tokenAmountController.text) ?? 0;
-    final double tokenPrice = double.tryParse(_tokenPriceController.text) ?? 0;
 
     setState(() {
-      _totalValue = tokenAmount * tokenPrice;
+      _totalValue = tokenAmount * widget.tokenPrice;
     });
   }
 
@@ -687,64 +726,64 @@ class CoinConvertCardState extends State<CoinConvertCard> {
           Column(
             spacing: GeniusWalletConsts.space6,
             children: [
-              // Read-only display of marketData.currentPrice (sketch 152: only
-              // Token Amount is editable).
+              // The live price is a FACT, not a field (sketch 164-A, Jakub
+              // 2026-07-29). It used to be a `GWTextField(readOnly: true)`
+              // wearing a bordered `READ-ONLY` chip in its `suffix`, and the
+              // chip was carrying the whole message on its own: the box was the
+              // same height, the same radius and nearly the same edge as the
+              // field directly beneath it, which you CAN type in.
               //
-              // 070-A: both fields left the notched Material floating label -
-              // the only pattern of its kind in the app besides
-              // `custom_drop_down.dart` - for `GWTextField`, which puts the
-              // label ABOVE the box at labelMd/textSecondary/space4 like every
-              // other field the app ships.
+              // A `GWDetailGrid` row settles it structurally instead of
+              // labelling it. Three things follow, and the third is the reason
+              // this beat the alternatives:
               //
-              // The READ-ONLY chip rides in `suffix` rather than beside the
-              // label because `GWTextField.label` is a `String`, not a `Widget`;
-              // growing it for one consumer fails the promotion test everything
-              // else this week was held to. It also lands on the thing it
-              // describes.
+              //  1. The card already speaks this language one row down - the
+              //     `Total` below is the same grid - so the price joins the
+              //     facts rather than impersonating an input.
+              //  2. The value keeps `textPrimary`. Sketch 164 measured the
+              //     obvious rival (keep the box, grey the value): that is
+              //     `textSecondary` on `surfaceSunken`, **6.20:1 dark but
+              //     4.23:1 light** - under the 4.5:1 body floor. This variant
+              //     has no such debt in either mode.
+              //  3. **A `readOnly` field still takes focus in Flutter.** The
+              //     old box could be tabbed into and would light up promising
+              //     an edit that cannot happen; the comment that used to live
+              //     here said so while shipping it anyway. A row cannot be
+              //     focused, so the defect is gone rather than annotated.
               //
-              // **The two fields rest at different edge weights on purpose.**
-              // The editable one is `borderControl` (3.30:1) via `focusRing`;
-              // this one keeps the component's `borderSubtle` default (1.32:1).
-              // A read-only display is not a UI component under 1.4.11, and the
-              // difference is information - the louder edge is the one you can
-              // type in. `focusRing` here was rejected deliberately: a
-              // `readOnly` field still takes focus in Flutter, so it would light
-              // a gradient promising an edit that cannot happen.
-              GWTextField(
-                controller: _tokenPriceController,
-                label: "Token price",
-                readOnly: true,
-                fill: gw.surfaceSunken,
-                keyboardType: const TextInputType.numberWithOptions(
-                  decimal: true,
-                ),
-                suffix: Padding(
-                  padding: const EdgeInsets.only(
-                    right: GeniusWalletConsts.space6,
-                  ),
-                  child: Align(
-                    alignment: Alignment.centerRight,
-                    widthFactor: 1,
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: GeniusWalletConsts.space2,
-                        vertical: 1,
-                      ),
-                      decoration: BoxDecoration(
-                        border: Border.all(color: gw.borderSubtle),
-                        borderRadius: BorderRadius.circular(
-                          GeniusWalletConsts.radiusXs,
+              // It also drops `_tokenPriceController`: the price arrived as a
+              // double, went through `toString()` into a controller and came
+              // back out through `double.tryParse` - a round trip that existed
+              // only because the display was an input.
+              GWDetailGrid(
+                rows: [
+                  Padding(
+                    padding: kGWDetailRowPadding,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          "Token price",
+                          style: GeniusWalletTypography.bodySm.copyWith(
+                            color: gw.textSecondary,
+                          ),
                         ),
-                      ),
-                      child: Text(
-                        "READ-ONLY",
-                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                          color: gw.textPrimary54,
+                        Text(
+                          NumberFormat.currency(
+                            locale: "en_US",
+                            symbol: "\$",
+                            decimalDigits: widget.tokenPrice >= 1 ? 2 : 6,
+                          ).format(widget.tokenPrice),
+                          style: GeniusWalletTypography.bodySm.copyWith(
+                            color: gw.textPrimary,
+                            fontWeight: FontWeight.w600,
+                            fontFeatures: const [FontFeature.tabularFigures()],
+                          ),
                         ),
-                      ),
+                      ],
                     ),
                   ),
-                ),
+                ],
               ),
               // The one editable control on this card, so it is the one that
               // gets the brand GRADIENT on focus. It lit a FLAT
@@ -1244,28 +1283,127 @@ class _StatRail extends StatelessWidget {
             : 2;
         final double gap = GeniusWalletConsts.space6.toDouble();
         final double w = (constraints.maxWidth - gap * (perRow - 1)) / perRow;
-        return Wrap(
-          spacing: gap,
-          runSpacing: gap,
-          children: [
-            for (final t in tiles)
-              SizedBox(
-                width: w,
-                child: GWCard(
-                  radius: GeniusWalletConsts.radiusMd,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: GeniusWalletConsts.space6,
-                    vertical: GeniusWalletConsts.space6,
-                  ),
-                  child: t,
-                ),
+        // Chunked Rows under IntrinsicHeight, NOT a Wrap. A `Wrap` places its
+        // children at their natural size and neither stretches nor equalises
+        // them, so the one tile carrying the range bar (`space4` + a 4px track
+        // = 12px more than the shared `GWStatTile`) stood 77px tall in a row of
+        // 65s. That single proud card is what read as broken on the 2026-07-29
+        // walk. `IntrinsicHeight` + `stretch` gives every card in a run the
+        // tallest one's height, and it is safe here in a way it is not around a
+        // chart: these subtrees are Text and a Container, all of which answer
+        // an intrinsic-height query cheaply.
+        final rows = <Widget>[];
+        for (var i = 0; i < tiles.length; i += perRow) {
+          final chunk = tiles.sublist(i, math.min(i + perRow, tiles.length));
+          rows.add(
+            IntrinsicHeight(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  for (var j = 0; j < chunk.length; j++) ...[
+                    if (j > 0) SizedBox(width: gap),
+                    SizedBox(
+                      width: w,
+                      child: GWCard(
+                        radius: GeniusWalletConsts.radiusMd,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: GeniusWalletConsts.space6,
+                          vertical: GeniusWalletConsts.space6,
+                        ),
+                        child: chunk[j],
+                      ),
+                    ),
+                  ],
+                ],
               ),
+            ),
+          );
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (var r = 0; r < rows.length; r++) ...[
+              if (r > 0) SizedBox(height: gap),
+              rows[r],
+            ],
           ],
         );
       },
     );
   }
 }
+
+/// The identity row's action glyph (sketch 164-C): a 32px bounded box carrying
+/// the brand gradient, riding inside `GWButton`'s 48px transparent target.
+///
+/// **Why a box at 32 rather than `GWButtonVariant.icon` at 48.** That variant
+/// paints at the button's full height, which would put a 48px chip beside a
+/// 32px title and reverse Jakub's 2026-07-28 call (*"te ikony powinny być
+/// wysokości tytułu, nie większe"*). Splitting them keeps the 48px tap target
+/// he separately chose to keep on 2026-07-29 AND a painted box no taller than
+/// the word next to it.
+///
+/// **Why the edge and not the fill.** On the page canvas (`surfaceBase`
+/// #0B0D12) `surfaceElevated` measures **1.01:1** and `surfaceMenu` **1.12:1** -
+/// neither is a boundary. `borderControl` is **3.28:1**, clearing 1.4.11's 3:1
+/// for the edge that now identifies the control. The fill is a lift, the border
+/// is the statement.
+///
+/// **Why `brandCtaText` and not `brandCta`.** The raw CTA gradient's two stops
+/// measure 10.39:1 and 7.54:1 on the dark canvas and **1.65:1 / 2.28:1 on a
+/// light one** - unreadable. `brandCtaText` collapses to the flat light-safe
+/// `brandPrimaryOnSurface` (#0A6885, 6.30:1) above the luminance threshold, so
+/// one paint path covers both appearances with no branch in the widget tree.
+///
+/// The [Icon] deliberately sets NO colour: `GWButton` supplies it through
+/// `IconTheme` and drops it to alpha 140 when disabled, and a `srcIn`
+/// `ShaderMask` masks the gradient by its child's alpha - so the disabled state
+/// keeps dimming rather than being painted over at full strength.
+class _ActionGlyph extends StatelessWidget {
+  const _ActionGlyph(this.icon, {this.enabled = true});
+
+  final IconData icon;
+
+  /// The box does not learn `onPressed == null` from `GWButton`, so the one
+  /// call site that can be disabled (Bridge, on a zero balance) passes it.
+  /// Without this the border would stay full strength around a dimmed glyph.
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    // Fail-soft read: registers the InheritedWidget dependency that forces this
+    // subtree to rebuild on a live appearance toggle (04-04 discipline).
+    final gw = Theme.of(context).extension<GWColors>() ?? GWColors.dark();
+    final Color edge = enabled
+        ? gw.borderControl
+        : gw.borderControl.withAlpha(140);
+    return Container(
+      width: 32,
+      height: 32,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: gw.surfaceMenu,
+        border: Border.all(color: edge),
+        borderRadius: BorderRadius.circular(GeniusWalletConsts.radiusSm),
+      ),
+      child: ShaderMask(
+        blendMode: BlendMode.srcIn,
+        shaderCallback: (bounds) => GeniusWalletGradient.brandCtaText(
+          gw.surfaceMenu,
+        ).createShader(bounds),
+        child: Icon(icon, size: 18),
+      ),
+    );
+  }
+}
+
+/// The 24h-range track and its position marker, keyed so the layout claims in
+/// `test/tokens/coin_page_range_tile_test.dart` can measure them.
+///
+/// Both were invisible to every other kind of check: the track's collapse to
+/// zero width is a `Stack` loose-constraint result, not a value anything reads.
+const Key kCoinRangeTrackKey = Key('coin-range-track');
+const Key kCoinRangeMarkerKey = Key('coin-range-marker');
 
 /// The 24h low/high tile: a [GWStatTile] with a position bar under it.
 ///
@@ -1297,22 +1435,43 @@ class _RangeTile extends StatelessWidget {
         if (known) ...[
           const SizedBox(height: GeniusWalletConsts.space4),
           // A 4px track with the current price's position along it. Decorative:
-          // the numbers above say the same thing, so 1.4.11 does not apply and
-          // borderSubtle is the right weight.
-          LayoutBuilder(
-            builder: (context, c) => Stack(
+          // the numbers above say the same thing, so 1.4.11 does not bind.
+          //
+          // **The track is `borderStrong`, not `surfaceSunken`.** The original
+          // painted the rail in the DEEPEST surface (#06080C) on top of a
+          // `surfaceElevated` card (#0C0E14) — a darker-on-dark fill about
+          // 1.1:1 against its own background, with a `borderSubtle` hairline
+          // (1.36:1) as its only edge. It was not a faint rail; on the walk it
+          // was no rail at all, and the 6px marker read as a teal dot floating
+          // under the numbers with nothing beneath it. Light mode hid the bug:
+          // there `surfaceSunken` is #CFD4DB, plainly visible on a white card.
+          // `borderStrong` is 24% of the ink/white axis, so it reads on BOTH
+          // canvases — which is the property the old pairing lacked, not extra
+          // weight for its own sake.
+          // `Align` on a fractional x, NOT a `LayoutBuilder` + `Positioned`.
+          // Alignment.x runs -1..1 across the free space with the child's own
+          // width already discounted, so `2t - 1` places the marker exactly
+          // where `left: (maxWidth - 6) * t` did — and it gets there without
+          // measuring. That matters: `LayoutBuilder` refuses intrinsic queries
+          // outright ("does not support returning intrinsic dimensions"), so
+          // one inside this tile threw the moment `_StatRail` wrapped the run
+          // in `IntrinsicHeight` to equalise the six card heights.
+          SizedBox(
+            height: 4,
+            child: Stack(
               children: [
                 Container(
+                  key: kCoinRangeTrackKey,
                   height: 4,
                   decoration: BoxDecoration(
-                    color: gw.surfaceSunken,
+                    color: gw.borderStrong,
                     borderRadius: BorderRadius.circular(2),
-                    border: Border.all(color: gw.borderSubtle, width: 0.5),
                   ),
                 ),
-                Positioned(
-                  left: (c.maxWidth - 6) * t,
+                Align(
+                  alignment: Alignment(2 * t - 1, 0),
                   child: Container(
+                    key: kCoinRangeMarkerKey,
                     width: 6,
                     height: 4,
                     decoration: BoxDecoration(

--- a/test/components/gw_hover_row_test.dart
+++ b/test/components/gw_hover_row_test.dart
@@ -1,0 +1,139 @@
+// GWHoverRow's contract, and the three defects it was extracted to close
+// (2026-07-30 walk: Assets had no hover, Markets had square corners,
+// Transactions had the treatment everyone should have had).
+//
+// The highlight itself is an ink feature - it is painted, not a widget - so it
+// cannot be found in the tree. What CAN be pinned is every input that decides
+// it, and those are exactly the three things that differed between the three
+// lists: whether a local Material exists to paint on, what radius clips it, and
+// what colour it uses instead of the theme default.
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genius_wallet/components/effects/gw_hover_row.dart';
+import 'package:genius_wallet/theme/genius_wallet_consts.dart';
+import 'package:genius_wallet/theme/gw_colors.dart';
+
+Widget _host({VoidCallback? onTap, GWColors? colors}) => MaterialApp(
+  theme: ThemeData(extensions: [colors ?? GWColors.dark()]),
+  home: Scaffold(
+    body: Center(
+      child: SizedBox(
+        width: 400,
+        child: GWHoverRow(
+          onTap: onTap,
+          child: const SizedBox(height: 56, child: Text('row')),
+        ),
+      ),
+    ),
+  ),
+);
+
+InkWell _inkOf(WidgetTester tester) =>
+    tester.widget<InkWell>(find.byType(InkWell));
+
+void main() {
+  testWidgets('the highlight is rounded at radiusMd, never square', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(onTap: () {}));
+
+    expect(
+      _inkOf(tester).borderRadius,
+      BorderRadius.circular(GeniusWalletConsts.radiusMd),
+      reason:
+          'a null borderRadius is what painted the Markets rows as '
+          'full-bleed rectangles while Transactions painted rounded',
+    );
+  });
+
+  testWidgets('it states its own hover colour instead of inheriting one', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(onTap: () {}));
+
+    final gw = GWColors.dark();
+    expect(
+      _inkOf(tester).hoverColor,
+      gw.textPrimary.withValues(alpha: kGWRowHoverAlpha),
+    );
+
+    // And it follows the appearance, because it is derived from a token that
+    // does: on light it must be INK-tinted, not white-tinted, or the highlight
+    // would brighten an already-white card into nothing.
+    await tester.pumpWidget(_host(onTap: () {}, colors: GWColors.light()));
+    expect(
+      _inkOf(tester).hoverColor,
+      GWColors.light().textPrimary.withValues(alpha: kGWRowHoverAlpha),
+    );
+  });
+
+  testWidgets('it carries its own Material, so the ink cannot be buried', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(onTap: () {}));
+
+    // The Assets bug: a ListTile paints its ink on the nearest ancestor
+    // Material, and on the dashboard that ancestor sits under the panel's own
+    // background. The nearest Material above the InkWell must belong to
+    // GWHoverRow and must be transparent, so it stacks ON the caller's paint
+    // rather than being covered by it.
+    final material = tester.widget<Material>(
+      find
+          .ancestor(of: find.byType(InkWell), matching: find.byType(Material))
+          .first,
+    );
+    expect(material.color, Colors.transparent);
+  });
+
+  testWidgets('a row that does nothing does not claim it does', (tester) async {
+    await tester.pumpWidget(_host());
+
+    expect(_inkOf(tester).onTap, isNull);
+    expect(_inkOf(tester).mouseCursor, SystemMouseCursors.basic);
+  });
+
+  testWidgets('a tappable row takes the click cursor', (tester) async {
+    await tester.pumpWidget(_host(onTap: () {}));
+
+    expect(_inkOf(tester).mouseCursor, SystemMouseCursors.click);
+  });
+
+  testWidgets('the hit area is exactly the child, not a padded box', (
+    tester,
+  ) async {
+    var taps = 0;
+    await tester.pumpWidget(_host(onTap: () => taps++));
+
+    final rowRect = tester.getRect(find.byType(GWHoverRow));
+    final childRect = tester.getRect(find.byType(Text));
+    expect(rowRect.width, 400);
+    expect(rowRect.height, 56);
+    expect(rowRect.contains(childRect.center), isTrue);
+
+    await tester.tap(find.byType(GWHoverRow));
+    expect(taps, 1);
+  });
+
+  testWidgets('hovering does not throw and repaints in place', (tester) async {
+    await tester.pumpWidget(_host(onTap: () {}));
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    await gesture.moveTo(tester.getCenter(find.byType(GWHoverRow)));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    // Geometry must not move under the pointer — a row hover that resized or
+    // lifted would make a list flicker as the pointer ran down it, which is
+    // the reason rows do not take the chip's "lift" response.
+    expect(tester.getRect(find.byType(GWHoverRow)).height, 56);
+
+    await gesture.moveTo(Offset.zero);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/dashboard/markets_hero_height_test.dart
+++ b/test/dashboard/markets_hero_height_test.dart
@@ -1,26 +1,21 @@
-// The claim under test: growing the Markets hero chart from 180 to 253 would
-// cost the WIDE card no height, because the right column sits in an
-// `IntrinsicHeight` row whose height comes from the taller LEFT column, and
-// the `Spacer` at markets_hero_card.dart:167 is holding 73px of slack.
+// The claim: growing the Markets hero chart from 180 to 253 costs the WIDE
+// card no height, because the right column sits in an `IntrinsicHeight` row
+// whose height comes from the taller LEFT column, and the `Spacer` in
+// `buildRight` absorbs the 73px difference.
 //
-// That number was DERIVED from the widget tree at 8ed02e78, not measured in a
-// running app — and 253 consumed the slack EXACTLY (left column 301 = 32
-// segment + 16 gap + 253 chart), landing on the boundary with zero margin. A
-// derivation that lands exactly on a boundary is precisely the kind that must
-// be measured, not trusted — and this one did not survive being measured.
+// **This file previously recorded that claim as FALSIFIED. It was not, and the
+// error was here rather than in the claim.** The old host wrapped the card in
+// `SizedBox(width: 1200)` and its comments asserted that width "clears
+// GeniusBreakpoints.medium (768), so this is the WIDE (IntrinsicHeight row)
+// layout". It never set `tester.view.physicalSize`, which defaults to 800x600,
+// so the `SizedBox` was clamped and the card rendered **stacked**. The stacked
+// branch passes `fill: false` - no `Spacer`, no `IntrinsicHeight` - so the card
+// grew by exactly the chart's delta, which is correct behaviour for the one
+// layout the claim was never about. 619.0 and 692.0 are stacked-layout numbers.
 //
-// **RESULT: the hypothesis was FALSIFIED.** This test was written and run
-// FIRST against the shipped 180px chart, recording the real card height as
-// `measuredCardHeight` below. Flipping `kMarketsHeroChartHeight` to 253 and
-// re-running the SAME assertion showed the wide card growing by 73px — the
-// exact amount the `Spacer` was supposed to be absorbing — so the "free on
-// wide" claim does not hold. Per this task's own instruction ("if the
-// wide-layout card grows, STOP and report it; do not accept a taller card
-// and do not adjust the constant to match"), `kMarketsHeroChartHeight` stays
-// at 180. This test now guards that regression: if a future change makes the
-// card grow at the SHIPPED height, or silently bumps the constant without
-// re-verifying the claim, this fails. See `260729-gt4-SUMMARY.md` for the
-// full writeup and the two candidate fixes.
+// The lesson is the one this repo keeps re-learning: a widget test that does
+// not set its surface is not testing the width it says it is. Both layouts are
+// now pinned, at surfaces that actually produce them.
 import 'dart:math';
 
 import 'package:fl_chart/fl_chart.dart';
@@ -35,8 +30,7 @@ CoinGeckoCoin _coin() =>
     CoinGeckoCoin(id: 'bitcoin', symbol: 'btc', name: 'Bitcoin');
 
 /// A 30-point RISING sparkline — `up` reads true, so the chart takes
-/// `statusSuccess`, matching the deterministic trend-colour rule under test
-/// in the implementation (not asserted directly here; the height claim is).
+/// `statusSuccess`, matching the deterministic trend-colour rule.
 List<double> _risingSparkline() =>
     List<double>.generate(30, (i) => 60000.0 + i * 120.0);
 
@@ -75,66 +69,108 @@ CoinGeckoMarketData _marketData() {
   );
 }
 
-/// The same shape as the hero's only real consumer, `markets_screen.dart:197`
-/// — a fixed-width column inside a `SingleChildScrollView`, which hands its
-/// child unbounded height in the scroll direction. 1200px clears
-/// `GeniusBreakpoints.medium` (768), so this is the WIDE (`IntrinsicHeight`
-/// row) layout, not the narrow stacked one.
+/// The same shape as the hero's only real consumer, `markets_screen.dart:197` —
+/// a column inside a `SingleChildScrollView`, which hands its child unbounded
+/// height in the scroll direction.
 Widget _host() => MaterialApp(
   theme: ThemeData(extensions: [GWColors.dark()]),
   home: Scaffold(
-    body: SizedBox(
-      width: 1200,
-      child: SingleChildScrollView(
-        child: MarketsHeroCard(coin: _coin(), data: _marketData()),
-      ),
+    body: SingleChildScrollView(
+      child: MarketsHeroCard(coin: _coin(), data: _marketData()),
     ),
   ),
 );
 
+extension on WidgetTester {
+  /// Sets the surface for real. Without this the default 800x600 decides the
+  /// layout branch no matter what the widget tree asks for — the whole reason
+  /// this file's earlier conclusion was wrong.
+  Future<void> pumpHeroAt(Size size) async {
+    view.physicalSize = size;
+    view.devicePixelRatio = 1.0;
+    addTearDown(view.reset);
+    await pumpWidget(_host());
+    await pump();
+  }
+}
+
 void main() {
-  group(
-    'wide markets hero: the "grow to 253 for free" hypothesis, measured',
-    () {
-      // Measured on this machine, 2026-07-29, against the SHIPPED
-      // `kMarketsHeroChartHeight = 180` at markets_hero_card.dart. Flipping
-      // the constant to 253 grew this by 73px (692.0) instead of holding —
-      // that is the falsified hypothesis this file documents. The constant
-      // stays at 180 pending Jakub's decision, so this pins the CURRENT,
-      // correct height.
-      const measuredCardHeight = 619.0;
+  group('wide markets hero: the Spacer really does absorb the chart', () {
+    // Measured 2026-07-30 at a surface actually set to 1400x1000. The card is
+    // the same height with a 180px chart and with a 253px one — re-verified by
+    // flipping the constant and re-running, which is the check the old version
+    // of this test believed it was doing.
+    const wideCardHeight = 367.0;
+    const intrinsicRowHeight = 301.0;
 
-      testWidgets('the card holds this height (measured, not derived)', (
-        tester,
-      ) async {
-        await tester.pumpWidget(_host());
-        await tester.pump();
+    testWidgets('the card holds its height at the shipped chart size', (
+      tester,
+    ) async {
+      await tester.pumpHeroAt(const Size(1400, 1000));
 
-        // A right column taller than the row would overflow the
-        // `IntrinsicHeight` row's own height and throw.
-        expect(tester.takeException(), isNull);
-
-        final cardSize = tester.getSize(find.byType(MarketsHeroCard));
-        expect(cardSize.height, measuredCardHeight);
-      });
-
-      testWidgets(
-        'the chart itself is the expected height — a squeezed chart cannot '
-        'pass by shrinking',
-        (tester) async {
-          await tester.pumpWidget(_host());
-          await tester.pump();
-
-          expect(tester.takeException(), isNull);
-
-          final chartSize = tester.getSize(find.byType(LineChart));
-          // Pinned to the SAME constant `markets_hero_card.dart` uses for its
-          // `SizedBox(height: ...)` around `_HeroChart` — 180 today, 253
-          // after Task 4(a). Read from the shipped literal so this test fails
-          // loudly (rather than silently) if the two constants ever diverge.
-          expect(chartSize.height, kMarketsHeroChartHeight);
-        },
+      expect(tester.takeException(), isNull);
+      expect(
+        tester.getSize(find.byType(MarketsHeroCard)).height,
+        wideCardHeight,
       );
-    },
-  );
+    });
+
+    testWidgets('the IntrinsicHeight row is driven by the LEFT column', (
+      tester,
+    ) async {
+      await tester.pumpHeroAt(const Size(1400, 1000));
+
+      // 301 is the left column's derived height to the pixel — 46 icon + 20 +
+      // 48 price + 16 + 24 pill + 24 + 1 rule + 24 + 39 stat + 20 + 39 stat.
+      // If the RIGHT column ever became the taller one this number moves, and
+      // the "free" chart height stops being free — which is the actual
+      // invariant behind the constant, not the card height alone.
+      expect(
+        tester.getSize(find.byType(IntrinsicHeight)).height,
+        intrinsicRowHeight,
+        reason:
+            'the right column now drives the row: the chart is no longer '
+            'free and kMarketsHeroChartHeight must be re-measured',
+      );
+    });
+
+    testWidgets('the chart fills the wide height and gets the frame', (
+      tester,
+    ) async {
+      await tester.pumpHeroAt(const Size(1400, 1000));
+
+      expect(tester.takeException(), isNull);
+
+      // The frame splits the box into plot + time row, so the LineChart is
+      // shorter than the SizedBox by exactly the time row. Asserting the
+      // relationship rather than a literal keeps this honest if either
+      // constant moves.
+      final chartHeight = tester.getSize(find.byType(LineChart)).height;
+      expect(chartHeight, lessThan(kMarketsHeroChartHeight));
+      expect(chartHeight, greaterThan(kMarketsHeroChartHeight - 40));
+
+      // The right axis is the frame's most visible promise: money labels on
+      // nice-rounded values down the right edge.
+      expect(find.textContaining(r'$6'), findsWidgets);
+    });
+  });
+
+  group('stacked markets hero: no Spacer, so no free height', () {
+    testWidgets('the stacked chart keeps 180 and stays axis-free', (
+      tester,
+    ) async {
+      await tester.pumpHeroAt(const Size(600, 1200));
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(IntrinsicHeight), findsNothing);
+
+      // 180 is below kChartFrameMinHeight, so the runtime rule gives this the
+      // axis-free chart — the LineChart takes the whole box with no time row
+      // beneath it.
+      expect(
+        tester.getSize(find.byType(LineChart)).height,
+        kMarketsHeroChartHeightStacked,
+      );
+    });
+  });
 }

--- a/test/tokens/coin_page_range_tile_test.dart
+++ b/test/tokens/coin_page_range_tile_test.dart
@@ -1,0 +1,138 @@
+// The 24h-range tile, pinned after the 2026-07-29 walk ("ten tab jest jakiś nie
+// halo"). These are layout claims a screenshot can only show and no unit test
+// could reach, so they are real renders at a real desktop width.
+//
+// **The first hypothesis was wrong and this test is what killed it.** The track
+// was read as collapsing to zero width — `Container(height: 4)` carries no
+// width, and a `Stack` lays its non-positioned children out under LOOSE
+// constraints. That reasoning skips a rule: a `Container` with no child and no
+// width expands to fill what it is offered, so the track was already spanning
+// the tile. It measured 189.0px on the first run, before any fix. The rail was
+// invisible for a COLOUR reason, not a layout one, and the fix moved
+// accordingly. The width assertion stays as the regression guard the wrong
+// theory earned.
+//
+// What was genuinely broken is the height: the bar costs `space4 + 4` on top of
+// the shared `GWStatTile`, and a `Wrap` neither stretches nor equalises its
+// children — so one card in a row of six stood proud of the other five.
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:genius_api/genius_api.dart';
+import 'package:genius_wallet/components/cards/gw_card.dart';
+import 'package:genius_wallet/hive/models/coin_gecko_market_data.dart';
+import 'package:genius_wallet/providers/network_tokens_provider.dart';
+import 'package:genius_wallet/theme/gw_colors.dart';
+import 'package:genius_wallet/tokens/token_info_screen.dart';
+import 'package:genius_wallet/wallets/cubit/wallet_details_cubit.dart';
+
+class _UnusedApi implements GeniusApi {
+  @override
+  dynamic noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}
+
+/// Built through `fromJson` rather than the 25-argument constructor, and with
+/// the same shape the walk was looking at: a price sitting near the LOW end of
+/// the day's range, so a marker pinned at t≈0.09 cannot be mistaken for a
+/// track that happens to start at the left edge.
+CoinGeckoMarketData _btc() => CoinGeckoMarketData.fromJson({
+  'id': 'bitcoin',
+  'symbol': 'btc',
+  'name': 'Bitcoin',
+  'image': '',
+  'current_price': 63514.0,
+  'market_cap': 1.27e12,
+  'market_cap_rank': 1,
+  'total_volume': 2.81e10,
+  'high_24h': 64700.0,
+  'low_24h': 63400.0,
+  'price_change_24h': -383.0,
+  'price_change_percentage_24h': -0.6,
+  'circulating_supply': 2.01e7,
+  'total_supply': 2.01e7,
+  'ath': 126000.0,
+  'ath_change_percentage': -49.62,
+});
+
+Widget _host(CoinGeckoMarketData data) => BlocProvider(
+  create: (_) => WalletDetailsCubit(
+    geniusApi: _UnusedApi(),
+    networkTokensProvider: NetworkTokensProvider(),
+  ),
+  child: MaterialApp(
+    theme: ThemeData(extensions: [GWColors.dark()]),
+    home: Builder(
+      builder: (context) => TokenInfoScreen(
+        walletDetailsCubit: context.read<WalletDetailsCubit>(),
+        marketData: data,
+      ),
+    ),
+  ),
+);
+
+void main() {
+  // Wide enough for the rail's own `>= 900` branch, so all six tiles share one
+  // run and the height comparison is between neighbours rather than rows.
+  const Size desktop = Size(1400, 1000);
+
+  Future<void> pumpCoinPage(WidgetTester tester) async {
+    tester.view.physicalSize = desktop;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(_host(_btc()));
+    await tester.pump();
+  }
+
+  testWidgets('the range track spans the tile instead of collapsing to 0', (
+    tester,
+  ) async {
+    await pumpCoinPage(tester);
+
+    final track = find.byKey(kCoinRangeTrackKey);
+    expect(track, findsOneWidget);
+
+    final double trackWidth = tester.getSize(track).width;
+    // The card is ~213 wide at this viewport, less padding. The exact number is
+    // layout's business; what matters is that a rail exists at all — the bug
+    // measured 0.0 here.
+    expect(
+      trackWidth,
+      greaterThan(80),
+      reason:
+          'the 24h-range track collapsed to $trackWidth — a Stack lays its '
+          'non-positioned children out loose, so a width-less Container is 0',
+    );
+
+    // And the marker must sit ON that track, not past its end.
+    final marker = find.byKey(kCoinRangeMarkerKey);
+    expect(marker, findsOneWidget);
+    final double trackLeft = tester.getTopLeft(track).dx;
+    final double markerLeft = tester.getTopLeft(marker).dx;
+    final double markerRight = markerLeft + tester.getSize(marker).width;
+    expect(markerLeft, greaterThanOrEqualTo(trackLeft - 0.01));
+    expect(markerRight, lessThanOrEqualTo(trackLeft + trackWidth + 0.01));
+  });
+
+  testWidgets('the range tile is the same height as its neighbours', (
+    tester,
+  ) async {
+    await pumpCoinPage(tester);
+
+    // GWKicker upper-cases what it is handed, so the rendered text is 'RANK',
+    // not the 'Rank' the call site writes.
+    Finder cardFor(String label) => find
+        .ancestor(of: find.text(label), matching: find.byType(GWCard))
+        .first;
+
+    final double rank = tester.getSize(cardFor('RANK')).height;
+    final double range = tester.getSize(cardFor('24H RANGE')).height;
+
+    expect(
+      range,
+      moreOrLessEquals(rank, epsilon: 0.5),
+      reason:
+          'the range card was $range against $rank for Rank — one tile in a '
+          'row of six standing proud is what read as broken on the walk',
+    );
+  });
+}


### PR DESCRIPTION
Five commits closing out the chart topic, reworking the coin page off sketch 164, and unifying the row hover into one component.

**Base is `ui-redesign-port`, not `main`.** Branched from `dce14b92`, which is your Phase 23 work - this branch carried no commits of its own before today.

## Gates, measured at the end, not quoted

| Gate | Result |
|---|---|
| `flutter analyze` | **1 issue**, and it is `test/account/account_drawer_show_test.dart` - untracked and local-only, see below |
| `tool/check_brace_style.sh --count` | **0** |
| `tool/check_raw_colors.sh --count` | **0** |
| `dart format --set-exit-if-changed lib` | **exit 0** |
| `flutter test` (all dirs except `test/account/`) | **688 pass / 0 fail** |

`test/account/account_drawer_show_test.dart` is still deliberately absent from git - it hangs the suite on `testWidgets` + a real Hive box, which is why every run here excludes `test/account/`. Not added.

## ⚠️ Read this before treating the PR as green

| Change | Status |
|---|---|
| Range tile, timeframe alignment | **Walked live by Jakub**, dark |
| Read-only row, action icons, hero frame | **Walked live by Jakub**, dark |
| Row hover: Transactions, Markets page, Assets | **Walked live by Jakub**, dark |
| Row hover: **dashboard Markets panel** | **NOT walked** - fixed after Jakub's last look. Hot reload clean, 688 tests pass, but no human has seen it |
| **Light mode, everything above** | **NOT walked at all** |

Every colour decision below carries a measured light-mode figure. Measured is not seen.

## The one finding worth your time: a "falsified" hypothesis that was not

`markets_hero_height_test.dart` recorded that growing the Markets hero chart 180 → 253 costs the wide card the full 73px, and the constant sat at 180 for that reason.

**That test never reached the wide layout.** Its host wraps the card in `SizedBox(width: 1200)` and its comments assert the width "clears GeniusBreakpoints.medium (768), so this is the WIDE (IntrinsicHeight row) layout" - but it never set `tester.view.physicalSize`, which defaults to **800x600**. The SizedBox was clamped and the card rendered **stacked**. The stacked branch passes `fill: false`: no `Spacer`, no `IntrinsicHeight`. So it grew by exactly the chart's delta, which is correct for the one layout the claim was never about. **619.0 and 692.0 are stacked-layout numbers.**

Re-measured with the surface actually set to 1400x1000: the `IntrinsicHeight` row reports **301.0**, the original derivation to the pixel, and the card holds **367.0** at both 180 and 253 - verified by flipping the constant and re-running, which is the check the old test believed it was doing. The arithmetic was right; the instrument was wrong, and the "missing 284px" the earlier handoff left unexplained was never a real gap.

**The rule this earns: a widget test that does not set its surface is not testing the width it says it is.** Worth a grep - this branch may not be the only place.

## What shipped

**`b6e495b5` · chart header reaches the right edge.** A loose `Flexible` and a `Spacer` both default to `flex: 1` and split free space 50/50; the unspent half lands AFTER the last child. Identical defect to the `gw_page_header.dart` fix from 2026-07-29, found in a second file.

**`83e014cc` · coin page.** The 24h-range rail was painted `surfaceSunken` #06080C on a `surfaceElevated` #0C0E14 card - **1.04:1**, darker than its own background - so it was invisible in dark and fine in light. Now `borderStrong`. The tile also stood **77px against its neighbours' 65px** because a `Wrap` neither stretches nor equalises; the rail is chunked `Row`s under `IntrinsicHeight`. The read-only price became a `GWDetailGrid` row: the rival (keep the box, grey the value) lost on **4.23:1 in light mode**, under the 4.5:1 floor. Action glyphs took a 32px bounded box inside the 48px target - `GWButtonVariant.icon` would have painted at 48 and reversed Jakub's 2026-07-28 call that they must not stand taller than the title. The edge carries it at **3.28:1** (`borderControl`); the fill cannot, at 1.01:1 on the page canvas.

**`a89bd384` · Markets hero takes the trading frame at 253.** See above. Stacked stays 180 and keeps the axis-free chart, under the same runtime A/B rule the coin page follows.

**`ccee5e47` · one row hover.** Three lists, three different failures. Assets had **no hover at all** because a `ListTile` paints its highlight on the nearest ancestor `Material`, which on the dashboard sits under the panel background - rendered, then covered. The dashboard Markets panel is a separate widget with the identical fault. The Markets table row was a bare `InkWell` with no `borderRadius`, so it painted square. Transactions was the only one with both a local transparent `Material` and `radiusMd`. All three also inherited `ThemeData.hoverColor`'s stock 4% (1.086); `GWHoverRow` states 6% of `textPrimary` instead, which is one surface step (**1.135**, against `surfaceMenu`'s 1.108).

**`2b44d845` · planning docs.** Sketch 164, the session handoff, and a todo for the rows left un-migrated.

## Left deliberately un-fixed - please do not "helpfully" fix

1. **The timeframe segment is still a fake.** `GWTimeframeSegment` has no `onChanged` by design (user decision 2026-07-21, "visual-only"), and the Markets hero carries its own separate copy. Tapping moves the chip and changes nothing. This is the agreed next task.
2. **Markets table rows keep a full-width bottom hairline under the rounded highlight** - that rule belongs to the table, not the row.
3. **Four more tappable rows were found and NOT migrated** (outside the scope set): `job_step_list.dart:161`, `sdk_account_manager.dart:710`, `submit_logs_screen.dart:661`, `bridge_screen.dart:824`. Filed as a todo.
4. **Two chart todos are now obsolete** - both describe the zoom/pan buttons `260729-gt4` deleted.
5. **`.planning/sketches/165-coin-page-schemes/` is not in this PR** - a parallel session was writing it as this one closed.

## Asks

- Is the rounded highlight over a full-width table hairline acceptable in Markets, or should the rule inset?
- Do you want the four remaining rows migrated in this branch or a follow-up?
- Anything blocking a light-mode pass being scheduled as its own walk?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
